### PR TITLE
商品編集画面作成

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -67,8 +67,9 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @item = Item.find(params[:id])
+    @item = current_user.items.find(params[:id])
     @purchases = @item.purchases.order(purchased_on: :desc)
+    @lowest_purchase = @item.purchases.order(:unit_price).first
   end
 
   private

--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -11,9 +11,36 @@ class PurchasesController < ApplicationController
   def new_step2
   end
 
+  def edit
+    @purchase = current_user.purchases.includes(:item, :store, item: :category).find(params[:id])
+  end
+
+  def update
+    purchase = current_user.purchases.find(params[:id])
+    ActiveRecord::Base.transaction do
+      purchase.update!(purchase_params)
+      purchase.item.update!(name: params[:item_name])
+      category = current_user.categories.find_or_create_by!(name: params[:category_name])
+      purchase.item.update!(category: category)
+      store = current_user.stores.find_or_create_by!(name: params[:store_name])
+      purchase.update!(store: store)
+    end
+      puts "成功 #{params.inspect}"
+      redirect_to item_path(purchase.item), notice: "更新しました"
+  rescue => e
+      puts "失敗"
+      render :edit
+  end
+
   def destroy
     purchase = current_user.purchases.find(params[:id])
     purchase.destroy
     redirect_to purchases_path, notice: "購入履歴を削除しました"
+  end
+
+  private
+
+  def purchase_params
+    params.require(:purchase).permit(:brand, :content_quantity, :content_unit, :pack_quantity, :pack_unit, :price, :purchased_on)
   end
 end

--- a/app/views/home/top.html.erb
+++ b/app/views/home/top.html.erb
@@ -1,4 +1,4 @@
-<div class = pt-20>
+<div>
   <h1>SokoNote</h1>
 
   <div class = "pt-2">

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -1,20 +1,19 @@
-<div class="bg-light-gray min-h-screen font-sans">
-  <%# メインコンテンツエリア：ヘッダー分（mt-4など）の余白を確保 %>
-  <main class="px-4 pt-20 space-y-4">
-    <% @items.each do |item| %>
-      <%= link_to item_path(item), class: "block bg-white rounded-2xl p-5 shadow-md border border-gray-100 no-underline active:bg-gray-50 transition-colors" do %>
-        <%# 商品名 %>
-        <h2 class="text-xl font-bold text-black mb-1">
-          <%= item.name %>
-        </h2>
-        
-        <%# 最安単価：単位は1mlで固定。価格は一旦「#」で表示 %>
-        <p class="text-dark-gray text-sm">
-          最安単価<span class="text-green font-bold ml-1">1単位あたり：#円</span>
-        </p>
-      <% end %>
+<div>
+<%# メインコンテンツエリア：ヘッダー分（mt-4など）の余白を確保 %>
+<div class="space-y-4">
+  <% @items.each do |item| %>
+    <%= link_to item_path(item), class: "block bg-white rounded-2xl p-5 shadow-md border border-gray-100 no-underline active:bg-gray-50 transition-colors" do %>
+      <%# 商品名 %>
+      <h2 class="text-xl font-bold text-black mb-1">
+        <%= item.name %>
+      </h2>
+      
+      <%# 最安単価：単位は1mlで固定。価格は一旦「#」で表示 %>
+      <p class="text-dark-gray text-sm">
+        最安単価<span class="text-green font-bold ml-1">1単位あたり：#円</span>
+      </p>
     <% end %>
-  </main>
+  <% end %>
 
   <%# 商品登録ボタン（FAB） %>
   <div class="fixed right-6 bottom-28">

--- a/app/views/items/new_step1.html.erb
+++ b/app/views/items/new_step1.html.erb
@@ -1,35 +1,33 @@
-<main class="px-4 pt-20 pb-60">
-  <h1 class= "text-xl mb-6">商品情報の登録</h1>
-  <%= form_with url: save_new_step1_items_path, method: :post, scope: :item_new_step1 do |f| %>
-    <div class ="flex flex-col gap-1 mb-6">
-      <%= f.label :item_name, "商品名", class: "text-sm"%>
-      <%= f.text_field :item_name, placeholder: "例：天然水 500ml", autocomplete: "off", class: "w-full p-3 bg-white border border-dark-gray rounded-lg focus:outline-none focus:ring-2 focus:ring-green placeholder-dark-gray"%>
+<h1 class= "text-xl mb-6">商品情報の登録</h1>
+<%= form_with url: save_new_step1_items_path, method: :post, scope: :item_new_step1 do |f| %>
+  <div class ="flex flex-col gap-1 mb-6">
+    <%= f.label :item_name, "商品名", class: "text-sm"%>
+    <%= f.text_field :item_name, placeholder: "例：天然水 500ml", autocomplete: "off", class: "w-full p-3 bg-white border border-dark-gray rounded-lg focus:outline-none focus:ring-2 focus:ring-green placeholder-dark-gray"%>
+  </div>
+  <div class ="flex flex-col gap-1 mb-6">
+    <%= f.label :category_name, "カテゴリ", class: "text-sm"%>
+    <%= f.text_field :category_name, placeholder: "例：食品・日用品", autocomplete: "off", class: "w-full p-3 bg-white border border-dark-gray rounded-lg focus:outline-none focus:ring-2 focus:ring-green placeholder-dark-gray"%>
+  </div>
+  <div class="flex gap-4 mb-6">
+    <div class="flex-1 flex flex-col gap-1">
+      <%= f.label :content_quantity, "内容量", class: "text-sm" %>
+      <%= f.text_field :content_quantity, placeholder: "例：3 , 500", autocomplete: "off", class: "w-full p-3 bg-white border border-dark-gray rounded-lg focus:outline-none focus:ring-2 focus:ring-green placeholder-dark-gray"%>
     </div>
-    <div class ="flex flex-col gap-1 mb-6">
-      <%= f.label :category_name, "カテゴリ", class: "text-sm"%>
-      <%= f.text_field :category_name, placeholder: "例：食品・日用品", autocomplete: "off", class: "w-full p-3 bg-white border border-dark-gray rounded-lg focus:outline-none focus:ring-2 focus:ring-green placeholder-dark-gray"%>
+    <div class="flex-1 flex flex-col gap-1">
+      <%= f.label :pack_quantity, "パック数", class: "text-sm" %>
+      <%= f.text_field :pack_quantity, value: 1, placeholder: "例：24 , 1", autocomplete: "off", class: "w-full p-3 bg-white border border-dark-gray rounded-lg focus:outline-none focus:ring-2 focus:ring-green placeholder-dark-gray"%>
     </div>
-    <div class="flex gap-4 mb-6">
-      <div class="flex-1 flex flex-col gap-1">
-        <%= f.label :content_quantity, "内容量", class: "text-sm" %>
-        <%= f.text_field :content_quantity, placeholder: "例：3 , 500", autocomplete: "off", class: "w-full p-3 bg-white border border-dark-gray rounded-lg focus:outline-none focus:ring-2 focus:ring-green placeholder-dark-gray"%>
-      </div>
-      <div class="flex-1 flex flex-col gap-1">
-        <%= f.label :pack_quantity, "パック数", class: "text-sm" %>
-        <%= f.text_field :pack_quantity, value: 1, placeholder: "例：24 , 1", autocomplete: "off", class: "w-full p-3 bg-white border border-dark-gray rounded-lg focus:outline-none focus:ring-2 focus:ring-green placeholder-dark-gray"%>
-      </div>
-    </div>
-    <div class="flex flex-col gap-1 mb-6">
-      <%= f.label :price, "価格", class: "text-sm" %>
-      <%= f.text_field :price, placeholder: "例：298 , 858", autocomplete: "off", class: "w-full p-3 bg-white border border-dark-gray rounded-lg focus:outline-none focus:ring-2 focus:ring-green placeholder-dark-gray"%>
-    </div>
-    <div class="flex flex-col gap-1">
-      <%= f.label :tax_rate, "税率", class: "text-sm" %>
-      <%= f.radio_button :tax_rate, 0, checked: true %>税抜<%= f.radio_button :tax_rate, 8 %>8%<%= f.radio_button :tax_rate, 10 %>10%
-    </div>
-    <div class="fixed right-6 bottom-28">
-      <%= f.submit "内容を確認して次へ", class: "bg-green text-white px-6 py-4 rounded-full shadow-lg flex items-center justify-center font-bold no-underline hover:opacity-90 transition-opacity" do %>
-      <% end %>
-    </div>
-  <% end %>
-</main>
+  </div>
+  <div class="flex flex-col gap-1 mb-6">
+    <%= f.label :price, "価格", class: "text-sm" %>
+    <%= f.text_field :price, placeholder: "例：298 , 858", autocomplete: "off", class: "w-full p-3 bg-white border border-dark-gray rounded-lg focus:outline-none focus:ring-2 focus:ring-green placeholder-dark-gray"%>
+  </div>
+  <div class="flex flex-col gap-1">
+    <%= f.label :tax_rate, "税率", class: "text-sm" %>
+    <%= f.radio_button :tax_rate, 0, checked: true %>税抜<%= f.radio_button :tax_rate, 8 %>8%<%= f.radio_button :tax_rate, 10 %>10%
+  </div>
+  <div class="fixed right-6 bottom-28">
+    <%= f.submit "内容を確認して次へ", class: "bg-green text-white px-6 py-4 rounded-full shadow-lg flex items-center justify-center font-bold no-underline hover:opacity-90 transition-opacity" do %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/items/new_step2.html.erb
+++ b/app/views/items/new_step2.html.erb
@@ -1,22 +1,20 @@
-<main class="px-4 pt-20">
-  <h1 class= "text-xl mb-6">その他情報の登録</h1>
-  <p>商品名: <%= @step1_data["item_name"] %></p>
-  <p>カテゴリ: <%= @step1_data["category_name"] %></p>
-  <p>内容量: <%= @step1_data["content_quantity"] %></p>
-  <p>パック数: <%= @step1_data["pack_quantity"] %></p>
-  <p>価格: <%= @step1_data["price"] %></p>
-  <p>税率: <%= @step1_data["tax_rate"] %></p>
-  <%= form_with url: items_path, method: :post, scope: :item_new_step2 do |f| %>
-    <%= f.label :brand, "メーカー名", class: "text-sm" %>
-    <%= f.text_field :brand, placeholder: "メーカー・ブランド名を入力", autocomplete: "off" %>
-    <%= f.label :store, "店舗名", class: "text-sm" %>
-    <%= f.text_field :store, placeholder: "例：〇〇スーパー〇〇店", autocomplete: "off" %>
-    <%= f.label :content_unit, "単位／内容量", class: "text-sm" %>
-    <%= f.text_field :content_unit, placeholder: "例：ml", autocomplete: "off" %>
-    <%= f.label :pack_unit, "単位／パック数", class: "text-sm" %>
-    <%= f.text_field :pack_unit, placeholder: "本,箱", autocomplete: "off" %>
-    <%= f.label :purchased_on, "登録日", class: "text-sm" %>
-    <%= f.date_field :purchased_on %>
-    <%= f.submit "この内容で登録する" %>
-  <% end %>
-</main>
+<h1 class= "text-xl mb-6">その他情報の登録</h1>
+<p>商品名: <%= @step1_data["item_name"] %></p>
+<p>カテゴリ: <%= @step1_data["category_name"] %></p>
+<p>内容量: <%= @step1_data["content_quantity"] %></p>
+<p>パック数: <%= @step1_data["pack_quantity"] %></p>
+<p>価格: <%= @step1_data["price"] %></p>
+<p>税率: <%= @step1_data["tax_rate"] %></p>
+<%= form_with url: items_path, method: :post, scope: :item_new_step2 do |f| %>
+  <%= f.label :brand, "メーカー名", class: "text-sm" %>
+  <%= f.text_field :brand, placeholder: "メーカー・ブランド名を入力", autocomplete: "off" %>
+  <%= f.label :store, "店舗名", class: "text-sm" %>
+  <%= f.text_field :store, placeholder: "例：〇〇スーパー〇〇店", autocomplete: "off" %>
+  <%= f.label :content_unit, "単位／内容量", class: "text-sm" %>
+  <%= f.text_field :content_unit, placeholder: "例：ml", autocomplete: "off" %>
+  <%= f.label :pack_unit, "単位／パック数", class: "text-sm" %>
+  <%= f.text_field :pack_unit, placeholder: "本,箱", autocomplete: "off" %>
+  <%= f.label :purchased_on, "登録日", class: "text-sm" %>
+  <%= f.date_field :purchased_on %>
+  <%= f.submit "この内容で登録する" %>
+<% end %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,21 +1,75 @@
-<main class ="pl-4 pt-20"> 
-  <h1>今までの<%= @item.name %>の購入履歴</h1>
-  <% @purchases.each do |purchase| %>
-    <div class= "bg-white mb-4 ">
-      <span><%= purchase.purchased_on %></span>
-      <span><%= purchase.store.name %></span>
-      <span><%= purchase.content_unit %></span>
-      <span><%= purchase.pack_unit %></span>
-      <span><%= purchase.price %></span>
-      <span>税<%= purchase.tax_rate %></span>
-      <span>1<%= purchase.content_unit %>あたり</span>
-      <span><%= purchase.unit_price %>円</span>
-      <%= link_to edit_purchase_path(purchase) do %>
-        <span>編集</span>
-      <% end %>
-      <%= link_to purchase_path(purchase), data: {turbo_method: :delete, turbo_confirm: "本当に削除しますか？" } do %>
-        <span>削除</span>
-      <% end %>
+<!-- 商品名 -->
+<h1 class="text-xl font-bold mb-4">
+  <%= @item.name %>（<%= @item.category.name %>）
+</h1>
+
+<!-- 現在の最安値 -->
+<% if @lowest_purchase.present? %>
+  <div class="bg-white rounded-xl p-4 shadow mb-6">
+
+    <p class="text-sm mb-2">
+      現在の最安値
+    </p>
+
+    <p class="text-xs mb-1">
+      1<%= @lowest_purchase.content_unit %>あたり
+    </p>
+
+    <p class="text-3xl font-bold mb-3">
+      <%= @lowest_purchase.unit_price.round(2) %>円
+    </p>
+
+    <div class="text-xs leading-relaxed">
+      <div><%= @lowest_purchase.purchased_on %></div>
+      <div><%= @lowest_purchase.brand %> ・ <%= @lowest_purchase.store.name %></div>
+      <div>
+        <%= @lowest_purchase.content_quantity %><%= @lowest_purchase.content_unit %>
+        <%= @lowest_purchase.pack_quantity %><%= @lowest_purchase.pack_unit %>
+      </div>
     </div>
-  <% end %>
-</main>
+  </div>
+<% end %>
+
+
+<!-- 今までの購入履歴 -->
+<h2 class="text-sm mb-3">
+  今までの購入履歴
+</h2>
+
+<% @purchases.each do |purchase| %>
+  <div class="bg-white rounded-xl p-4 shadow mb-4">
+
+    <div class="text-xs mb-1">
+      <%= purchase.purchased_on %>
+      <%= purchase.brand %>
+    </div>
+    <div class= "text-xs">
+      <%= purchase.store.name %>
+    </div>
+    <div class= "text-xs">
+      <%= purchase.content_quantity %><%= purchase.content_unit %>
+      <%= purchase.pack_quantity %><%= purchase.pack_unit %>
+    </div>
+    <div class="text-xl">
+      合計：<%= purchase.price %>円（税<% if purchase.tax_rate == 0 %>抜<% else %><%= purchase.tax_rate %>%<% end %>）
+    </div>
+    <div>
+      <span>
+        1<%= purchase.content_unit %>あたり
+      </span>
+      <span class="text-xl font-bold">
+        <%= purchase.unit_price.round(2) %>円
+      <span>
+    </div>
+    <!-- 編集・削除 -->
+    <div class="flex gap-4 mt-3">
+      <%= link_to "編集", edit_purchase_path(purchase),
+            class: "underline" %>
+
+      <%= link_to "削除", purchase_path(purchase),
+            data: { turbo_method: :delete,
+                    turbo_confirm: "本当に削除しますか？" },
+            class: "underline" %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,13 +19,15 @@
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@100..900&family=Roboto:ital,wght@0,100..900;1,100..900&display=swap" />
     <!-- Googleアイコンの取得 （全アイコンを取得してしまっているため要検討）-->
     <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
-    </head>
+  </head>
 
-  <body class = "bg-light-gray ">
-  <%= render 'shared/header' %>
-  <%= yield %>
-  <% if user_signed_in? %>
+  <body class="bg-light-gray">
+    <%= render 'shared/header' %>
+    <main class= "px-4 pt-20 pb-60">
+      <%= yield %>
+    </main>
+    <% if user_signed_in? %>
     <%= render 'shared/footer' %>
-  <% end %>
+    <% end %>
   </body>
 </html>

--- a/app/views/purchases/edit.html.erb
+++ b/app/views/purchases/edit.html.erb
@@ -1,0 +1,111 @@
+<h1 class="text-xl font-bold">商品情報の更新</h1>
+<div class= "mb-6"><%= @purchase.item.category.name %> <%= @purchase.item.name %>
+</div>
+
+
+<%= form_with model: @purchase, local: true do |f| %>
+
+  <!-- 商品名（item） -->
+  <div class="flex flex-col gap-1 mb-6">
+    <%= label_tag :item_name, "商品名", class: "text-sm" %>
+    <%= text_field_tag :item_name,
+          @purchase.item.name,
+          class: "w-full p-3 bg-white border border-dark-gray rounded-lg focus:ring-2 focus:ring-green" %>
+  </div>
+
+  <!-- カテゴリ（item.category） -->
+  <div class="flex flex-col gap-1 mb-6">
+    <%= label_tag :category_name, "カテゴリ", class: "text-sm" %>
+    <%= text_field_tag :category_name,
+          @purchase.item.category&.name,
+          class: "w-full p-3 bg-white border border-dark-gray rounded-lg focus:ring-2 focus:ring-green" %>
+  </div>
+
+  <!-- メーカー名（purchase） -->
+  <div class="flex flex-col gap-1 mb-6">
+    <%= f.label :brand, "メーカー名", class: "text-sm" %>
+    <%= f.text_field :brand,
+          class: "w-full p-3 bg-white border border-dark-gray rounded-lg focus:ring-2 focus:ring-green" %>
+  </div>
+
+  <!-- 店舗名（store） -->
+  <div class="flex flex-col gap-1 mb-6">
+    <%= label_tag :store_name, "店舗名", class: "text-sm" %>
+    <%= text_field_tag :store_name,
+          @purchase.store&.name,
+          class: "w-full p-3 bg-white border border-dark-gray rounded-lg focus:ring-2 focus:ring-green" %>
+  </div>
+
+  <!-- 内容量 / 単位 -->
+  <div class="flex gap-4 mb-6">
+    <div class="flex-1 flex flex-col gap-1">
+      <%= f.label :content_quantity, "内容量", class: "text-sm" %>
+      <%= f.number_field :content_quantity,
+            class: "w-full p-3 bg-white border border-dark-gray rounded-lg focus:ring-2 focus:ring-green" %>
+    </div>
+
+    <div class="flex-1 flex flex-col gap-1">
+      <%= f.label :content_unit, "単位 / 内容量", class: "text-sm" %>
+      <%= f.text_field :content_unit,
+            class: "w-full p-3 bg-white border border-dark-gray rounded-lg focus:ring-2 focus:ring-green" %>
+    </div>
+  </div>
+
+  <!-- パック数 / 単位 -->
+  <div class="flex gap-4 mb-6">
+    <div class="flex-1 flex flex-col gap-1">
+      <%= f.label :pack_quantity, "パック数", class: "text-sm" %>
+      <%= f.number_field :pack_quantity,
+            class: "w-full p-3 bg-white border border-dark-gray rounded-lg focus:ring-2 focus:ring-green" %>
+    </div>
+
+    <div class="flex-1 flex flex-col gap-1">
+      <%= f.label :pack_unit, "単位 / パック数", class: "text-sm" %>
+      <%= f.text_field :pack_unit,
+            class: "w-full p-3 bg-white border border-dark-gray rounded-lg focus:ring-2 focus:ring-green" %>
+    </div>
+  </div>
+
+  <!-- 価格 -->
+  <div class="flex flex-col gap-1 mb-6">
+    <%= f.label :price, "価格", class: "text-sm" %>
+    <%= f.number_field :price,
+          class: "w-full p-3 bg-white border border-dark-gray rounded-lg focus:ring-2 focus:ring-green" %>
+  </div>
+
+  <!-- 税率 -->
+  <div class="flex flex-col gap-1 mb-6">
+    <%= f.label :tax_rate, "税率", class: "text-sm" %>
+
+    <div class="flex gap-6 mt-2">
+      <label class="flex items-center gap-2">
+        <%= f.radio_button :tax_rate, 0 %>
+        税抜
+      </label>
+
+      <label class="flex items-center gap-2">
+        <%= f.radio_button :tax_rate, 8 %>
+        8%
+      </label>
+
+      <label class="flex items-center gap-2">
+        <%= f.radio_button :tax_rate, 10 %>
+        10%
+      </label>
+    </div>
+  </div>
+
+  <!-- 登録日 -->
+  <div class="flex flex-col gap-1 mb-10">
+    <%= f.label :purchased_on, "登録日", class: "text-sm" %>
+    <%= f.date_field :purchased_on,
+          class: "w-full p-3 bg-white border border-dark-gray rounded-lg focus:ring-2 focus:ring-green" %>
+  </div>
+
+  <!-- 更新ボタン -->
+  <div class="fixed right-6 bottom-28">
+    <%= f.submit "この内容で更新する",
+          class: "bg-green text-white px-8 py-4 rounded-full shadow-lg font-bold hover:opacity-90" %>
+  </div>
+
+<% end %>

--- a/app/views/purchases/new_step1.html.erb
+++ b/app/views/purchases/new_step1.html.erb
@@ -1,4 +1,4 @@
-<div class="bg-light-gray min-h-screen font-sans pb-24">
+<div>
   <main class="px-4 pt-20 space-y-4">
     <h2 class = "font-bold text-lg">商品情報の入力</h2>
     <%= form_with(model: @item) do |f| %>

--- a/app/views/setting/index.html.erb
+++ b/app/views/setting/index.html.erb
@@ -1,7 +1,5 @@
-<div class= pt-20>
-  <h1>設定画面</h1>
-  <div class= p-2>
-    <%= button_to "ログアウトする", destroy_user_session_path, method: :delete, class: "inline-block bg-green text-white px-6 py-2 rounded hover:bg-green-600 focus:outline-none focus:ring-green-400" %>
-  </div>
+<h1>設定画面</h1>
+<div class= p-2>
+  <%= button_to "ログアウトする", destroy_user_session_path, method: :delete, class: "inline-block bg-green text-white px-6 py-2 rounded hover:bg-green-600 focus:outline-none focus:ring-green-400" %>
 </div>
 

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,4 +1,4 @@
-<div class= pt-20>
+<div>
   <h2>Log in</h2>
 
   <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>


### PR DESCRIPTION
### 概要
商品編集画面を実装し、商品のCRUD操作（更新・削除）をWebアプリ上で完結できるようにする。

### 実施内容
- 商品詳細画面から編集画面へ遷移できる
- フォームに既存データが表示される
- 更新後、商品詳細画面に反映される
### 関連Issue
Closes #19 