### PR TITLE
新規商品登録画面の入力フォーム表記の改善

### DIFF
--- a/app/views/items/new_step1.html.erb
+++ b/app/views/items/new_step1.html.erb
@@ -1,34 +1,75 @@
-<h1 class= "text-xl mb-6">商品情報の登録</h1>
-<%= form_with model: @form, url: save_new_step1_items_path, method: :post, scope: :item_new_step1 do |f| %>
-  <%= render 'shared/error_messages', object: @form %>
-  <div class ="flex flex-col gap-1 mb-6">
-    <%= f.label :item_name, class: "text-sm"%>
-    <%= f.text_field :item_name, placeholder: "例：天然水 500ml", autocomplete: "off", class: "w-full p-3 bg-white border border-dark-gray rounded-lg focus:outline-none focus:ring-2 focus:ring-green placeholder-dark-gray"%>
-  </div>
-  <div class ="flex flex-col gap-1 mb-6">
-    <%= f.label :category_name, class: "text-sm"%>
-    <%= f.text_field :category_name, placeholder: "例：食品・日用品", autocomplete: "off", class: "w-full p-3 bg-white border border-dark-gray rounded-lg focus:outline-none focus:ring-2 focus:ring-green placeholder-dark-gray"%>
-  </div>
-  <div class="flex gap-4 mb-6">
-    <div class="flex-1 flex flex-col gap-1">
-      <%= f.label :content_quantity, class: "text-sm" %>
-      <%= f.number_field :content_quantity, placeholder: "例：3 , 500", autocomplete: "off", class: "w-full p-3 bg-white border border-dark-gray rounded-lg focus:outline-none focus:ring-2 focus:ring-green placeholder-dark-gray"%>
-    </div>
-    <div class="flex-1 flex flex-col gap-1">
-      <%= f.label :pack_quantity, class: "text-sm" %>
-      <%= f.number_field :pack_quantity, value: 1, placeholder: "例：24 , 1", autocomplete: "off", class: "w-full p-3 bg-white border border-dark-gray rounded-lg focus:outline-none focus:ring-2 focus:ring-green placeholder-dark-gray"%>
-    </div>
-  </div>
-  <div class="flex flex-col gap-1 mb-6">
-    <%= f.label :price, class: "text-sm" %>
-    <%= f.number_field :price, placeholder: "例：298 , 858", autocomplete: "off", class: "w-full p-3 bg-white border border-dark-gray rounded-lg focus:outline-none focus:ring-2 focus:ring-green placeholder-dark-gray"%>
-  </div>
-  <div class="flex flex-col gap-1">
-    <%= f.label :tax_rate, class: "text-sm" %>
-    <%= f.radio_button :tax_rate, 0, checked: true %>税抜<%= f.radio_button :tax_rate, 8 %>8%<%= f.radio_button :tax_rate, 10 %>10%
-  </div>
-  <div class="fixed right-6 bottom-28">
-    <%= f.submit "内容を確認して次へ", class: "bg-green text-white px-6 py-4 rounded-full shadow-lg flex items-center justify-center font-bold no-underline hover:opacity-90 transition-opacity" do %>
+<!-- 商品新規登録画面 2-1 -->
+<div class"flex flex-col md:flex-row items-center justify-center gap-6 p-4">
+  <div class="bg-white rounded-3xl shadow-xl w-full px-7 py-8">
+    <h1 class= "text-center text-2xl font-bold text-gray-800 mb-6">商品情報の登録</h1>
+    <%= form_with model: @form, url: save_new_step1_items_path, method: :post, scope: :item_new_step1 do |f| %>
+      <%= render 'shared/error_messages', object: @form %>
+      
+      <div class ="mb-5">
+        <%= f.label :item_name, class: "block text-gray-700 text-sm font-semibold mb-2"%>
+        <div class="flex items-center border border-gray-200 rounded-xl px-3 py-3 bg-white focus-within:border-[#6abf3b] focus-within:ring-1 focus-within:ring-[#6abf3b] transition">
+          <%= f.text_field :item_name, placeholder: "例：牛乳 / 箱ティッシュ", autofocus: true, autocomplete: "off", class: "flex-1 outline-none text-gray-700 text-sm bg-transparent placeholder-gray-400"%>
+        </div>
+      </div>
+
+      <div class ="mb-5">
+        <%= f.label :category_name, class: "block text-gray-700 text-sm font-semibold mb-2"%>
+        <div class="flex items-center border border-gray-200 rounded-xl px-3 py-3 bg-white focus-within:border-[#6abf3b] focus-within:ring-1 focus-within:ring-[#6abf3b] transition">
+          <%= f.text_field :category_name, placeholder: "例：飲料 / 日用品", autocomplete: "off", class: "flex-1 outline-none text-gray-700 text-sm bg-transparent placeholder-gray-400"%>
+        </div>
+      </div>
+
+      <div class="mb-5">
+        <div class="grid grid-cols-2 gap-3"">
+          <div class="flex flex-col">
+            <%= f.label :content_quantity, class: "block text-gray-700 text-sm font-semibold mb-2" %>
+            <div class="flex items-center border border-gray-200 rounded-xl px-3 py-3 bg-white focus-within:border-[#6abf3b] focus-within:ring-1 focus-within:ring-[#6abf3b] transition">
+              <%= f.number_field :content_quantity, value: 1, placeholder: "例：3 , 500", autocomplete: "off", class: "flex-1 outline-none text-gray-700 text-sm bg-transparent placeholder-gray-400"%>
+            </div>
+          </div>
+          <div class="flex flex-col">
+            <%= f.label :pack_quantity, class: "block text-gray-700 text-sm font-semibold mb-2" %>
+            <div class="flex items-center border border-gray-200 rounded-xl px-3 py-3 bg-white focus-within:border-[#6abf3b] focus-within:ring-1 focus-within:ring-[#6abf3b] transition">
+              <%= f.number_field :pack_quantity, value: 1, placeholder: "例：24 , 1", autocomplete: "off", class: "flex-1 outline-none text-gray-700 text-sm bg-transparent placeholder-gray-400"%>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="mb-5">
+        <%= f.label :price, class: "block text-gray-700 text-sm font-semibold mb-2" %>
+        <div class="w-fll flex items-center border border-gray-200 rounded-xl px-3 py-3 bg-white focus-within:border-[#6abf3b] focus-within:ring-1 focus-within:ring-[#6abf3b] transition">
+          <%= f.number_field :price, placeholder: "例：298 / 1200", autocomplete: "off", class: "w-fll flex-1 outline-none text-gray-700 text-sm bg-transparent placeholder-gray-400"%>
+        </div>
+      </div>
+      <div class="space-y-2 mb-5">
+      <%= f.label :tax_rate, class: "block text-gray-700 text-sm font-semibold mb-2" %>
+      <div class="segmented-control flex bg-gray-100 dark:bg-gray-800 p-1 rounded-xl">
+        
+        <%# 税抜 (値: 0) %>
+        <div class="flex-1">
+          <%= f.radio_button :tax_rate, 0, checked: true, class: "hidden peer", id: "tax-none" %>
+          <%= f.label :tax_rate, "税抜", value: 0, for: "tax-none", 
+              class: "block text-center py-2 text-sm font-medium text-gray-500 dark:text-gray-400 rounded-lg cursor-pointer transition-all peer-checked:bg-white peer-checked:text-[#6abf3b] peer-checked:shadow-sm" %>
+        </div>
+
+        <%# 8% (値: 8) %>
+        <div class="flex-1">
+          <%= f.radio_button :tax_rate, 8, class: "hidden peer", id: "tax-8" %>
+          <%= f.label :tax_rate, "8%", value: 8, for: "tax-8", 
+              class: "block text-center py-2 text-sm font-medium text-gray-500 dark:text-gray-400 rounded-lg cursor-pointer transition-all peer-checked:bg-white peer-checked:text-[#6abf3b] peer-checked:shadow-sm" %>
+        </div>
+
+        <%# 10% (値: 10) %>
+        <div class="flex-1">
+          <%= f.radio_button :tax_rate, 10, class: "hidden peer", id: "tax-10" %>
+          <%= f.label :tax_rate, "10%", value: 10, for: "tax-10", 
+              class: "block text-center py-2 text-sm font-medium text-gray-500 dark:text-gray-400 rounded-lg cursor-pointer transition-all peer-checked:bg-white peer-checked:text-[#6abf3b] peer-checked:shadow-sm" %>
+        </div>
+      </div>
+      <div class="fixed bottom-28 left-0 right-0 mx-auto max-w-xl px-6 flex justify-end">
+        <%= f.submit "内容を確認して次へ", class: "bg-[#6abf3b] text-white px-6 py-4 rounded-full shadow-lg flex items-center justify-center font-bold no-underline hover:opacity-90 transition-opacity cursor-pointer" do %>
+        <% end %>
+      </div>
     <% end %>
   </div>
-<% end %>
+</div>

--- a/app/views/items/new_step2.html.erb
+++ b/app/views/items/new_step2.html.erb
@@ -1,4 +1,4 @@
-<h1 class= "text-xl mb-6">その他情報の登録</h1>
+<!-- 商品新規登録画面 2-2 -->
 <%= render 'shared/error_messages', object: @form %>
 <div class= "bg-white rounded-xl p-4 shadow mb-6 ">
   <div class="flex items-center justify-between border-b border-gray-100 pb-2 mb-4">
@@ -33,28 +33,46 @@
   </div>
 </div>
 
-<%= form_with model: @form, url: items_path, method: :post, scope: :item_new_step2 do |f| %>
-  <div class ="flex flex-col gap-1 mb-6">
-    <%= f.label :brand, "メーカー名", class: "text-sm" %>
-    <%= f.text_field :brand, placeholder: "メーカー・ブランド名を入力", autocomplete: "off", class: "w-full p-3 bg-white border border-dark-gray rounded-lg focus:outline-none focus:ring-2 focus:ring-green placeholder-dark-gray" %>
-  </div>
-  <div class ="flex flex-col gap-1 mb-6">
-    <%= f.label :store, "店舗名", class: "text-sm" %>
-    <%= f.text_field :store, placeholder: "例：〇〇スーパー〇〇店", autocomplete: "off", class: "w-full p-3 bg-white border border-dark-gray rounded-lg focus:outline-none focus:ring-2 focus:ring-green placeholder-dark-gray"%>
-  </div>
-  <div class ="flex flex-col gap-1 mb-6">
-    <%= f.label :content_unit, "単位／内容量", class: "text-sm" %>
-    <%= f.text_field :content_unit, placeholder: "例：ml", autocomplete: "off", class: "w-full p-3 bg-white border border-dark-gray rounded-lg focus:outline-none focus:ring-2 focus:ring-green placeholder-dark-gray"%>
-  </div>
-  <div class ="flex flex-col gap-1 mb-6">
-    <%= f.label :pack_unit, "単位／パック数", class: "text-sm" %>
-    <%= f.text_field :pack_unit, placeholder: "本,箱", autocomplete: "off", class: "w-full p-3 bg-white border border-dark-gray rounded-lg focus:outline-none focus:ring-2 focus:ring-green placeholder-dark-gray"%>
-  </div>
-    <%= f.label :purchased_on, "登録日", class: "text-sm" %>
-    <%= f.date_field :purchased_on, value: Date.today, class: "w-full p-3 bg-white border border-dark-gray rounded-lg focus:outline-none focus:ring-2 focus:ring-green placeholder-dark-gray"%>
-  <div>
-  <div class="fixed right-6 bottom-28">
-    <%= f.submit "この内容で登録する", class: "bg-green text-white px-6 py-4 rounded-full shadow-lg flex items-center justify-center font-bold no-underline hover:opacity-90 transition-opacity" do %> %>
-    <% end %>
-  </div>
-<% end %>
+<div class"flex flex-col md:flex-row items-center justify-center gap-6 p-4">
+  <div class="bg-white rounded-3xl shadow-xl w-full px-7 py-8">
+  <h1 class= "text-center text-2xl font-bold text-gray-800 mb-6">その他情報の登録</h1>
+
+  <%= form_with model: @form, url: items_path, method: :post, scope: :item_new_step2 do |f| %>
+
+    <div class ="mb-5">
+      <%= f.label :brand, "メーカー名", class: "block text-gray-700 text-sm font-semibold mb-2" %>
+      <div class="flex items-center border border-gray-200 rounded-xl px-3 py-3 bg-white focus-within:border-[#6abf3b] focus-within:ring-1 focus-within:ring-[#6abf3b] transition">
+        <%= f.text_field :brand, placeholder: "例：伊藤園 / アタック", autofocus: true, autocomplete: "off", class: "flex-1 outline-none text-gray-700 text-sm bg-transparent placeholder-gray-400" %>
+      </div>
+    </div>
+
+    <div class ="mb-5">
+      <%= f.label :store, "店舗名", class: "block text-gray-700 text-sm font-semibold mb-2" %>
+      <div class="flex items-center border border-gray-200 rounded-xl px-3 py-3 bg-white focus-within:border-[#6abf3b] focus-within:ring-1 focus-within:ring-[#6abf3b] transition">
+        <%= f.text_field :store, placeholder: "例：〇〇スーパー〇〇店 / 〇〇薬局", autocomplete: "off", class: "flex-1 outline-none text-gray-700 text-sm bg-transparent placeholder-gray-400"%>
+      </div>
+    </div>
+    <div class ="mb-5">
+      <%= f.label :content_unit, "単位／内容量", class: "block text-gray-700 text-sm font-semibold mb-2" %>
+      <div class="flex items-center border border-gray-200 rounded-xl px-3 py-3 bg-white focus-within:border-[#6abf3b] focus-within:ring-1 focus-within:ring-[#6abf3b] transition">
+        <%= f.text_field :content_unit, placeholder: "例：ml、g、枚、本 など", autocomplete: "off", class: "flex-1 outline-none text-gray-700 text-sm bg-transparent placeholder-gray-400"%>
+      </div>
+    </div>
+    <div class ="mb-5">
+      <%= f.label :pack_unit, "単位／パック数", class: "block text-gray-700 text-sm font-semibold mb-2" %>
+      <div class="flex items-center border border-gray-200 rounded-xl px-3 py-3 bg-white focus-within:border-[#6abf3b] focus-within:ring-1 focus-within:ring-[#6abf3b] transition">
+        <%= f.text_field :pack_unit, placeholder: "パック、箱、袋 など", autocomplete: "off", class: "flex-1 outline-none text-gray-700 text-sm bg-transparent placeholder-gray-400"%>
+      </div>
+    </div>
+    <div class ="mb-5">
+      <%= f.label :purchased_on, "登録日", class: "block text-gray-700 text-sm font-semibold mb-2" %>
+      <div class="flex items-center border border-gray-200 rounded-xl px-3 py-3 bg-white focus-within:border-[#6abf3b] focus-within:ring-1 focus-within:ring-[#6abf3b] transition">
+        <%= f.date_field :purchased_on, value: Date.today, class: "flex-1 outline-none text-gray-700 text-sm bg-transparent placeholder-gray-400"%>
+      </div>
+    <div>
+    <div class="fixed bottom-28 left-0 right-0 mx-auto max-w-xl px-6 flex justify-end">
+      <%= f.submit "この内容で登録する", class: "bg-[#6abf3b] text-white px-6 py-4 rounded-full shadow-lg flex items-center justify-center font-bold no-underline hover:opacity-90 transition-opacity cursor-pointer" do %>
+      <% end %>
+    </div>
+  <% end %>
+</div>


### PR DESCRIPTION
### 概要
新規商品登録画面のデザインを調整し、各入力フォームのラベル（項目名）を分かりやすい表現に変更する。
### 実施内容
- 新規商品登録画面のレイアウトが見やすくなっている
- 各入力項目の名前がユーザー目線の表現に変更されている
### 関連Issue
Closes #99 