### PR TITLE
購入履歴editアクションにおける、コールバック例外エラーの修正

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -89,6 +89,7 @@ class ItemsController < ApplicationController
     @item = current_user.items.find(params[:id])
     @purchases = @item.purchases.order(purchased_on: :desc)
     @lowest_purchase = @item.purchases.order(:unit_price).first
+    puts "セッションの確認#{session.inspect}"
   end
 
   private

--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -1,18 +1,9 @@
 class PurchasesController < ApplicationController
     before_action :authenticate_user!
-  def new_step1
-    puts "リクエスト情報#{params}"
-    @item = Item.find(params[:item_id])
-  end
-
-  def session
-  end
-
-  def new_step2
-  end
 
   def edit
     puts "パラメータ詳細#{params.inspect}"
+    puts "sessionの確認#{session.inspect}"
     @purchase = current_user.purchases.includes(:item, :store, item: :category).find(params[:id])
     @form = PurchaseForm.new(
       item_name:        @purchase.item.name,


### PR DESCRIPTION
### 概要
購入履歴の編集画面に遷移する際に、NoMethodErrorになる原因を追求しエラーを修正する
### 実施内容
- 組み込みメソッドじゃないsession（不要な記述）を削除
- 他の遷移が問題ないか再度確認
### 関連Issue
Closes #109
