### PR TITLE
過去の購入履歴から商品を選択して比較フォームに反映する機能の実装

### DIFF
--- a/app/controllers/comparison_controller.rb
+++ b/app/controllers/comparison_controller.rb
@@ -1,5 +1,14 @@
 class ComparisonController < ApplicationController
   before_action :authenticate_user!
   def index
+    puts "パラメータ詳細#{params.inspect}"
+    puts "sessionの確認#{session.inspect}"
+
+    # 購入履歴（最安値）からデータがパラメータに存在するときのみ実行、それ以外は処理を終了させる
+    return unless params[:purchase_id].present?
+    # パラメータから取得した購入履歴（最安値）を取得
+    @purchase = current_user.purchases.find(params[:purchase_id])
+
+    puts "変数データの確認#{@purchase.inspect}"
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -86,10 +86,12 @@ class ItemsController < ApplicationController
   end
 
   def show
+    # 商品名・カテゴリ名表示のため取得
     @item = current_user.items.find(params[:id])
+    # 購入履歴を降順（最新を上に表示）で取得
     @purchases = @item.purchases.order(purchased_on: :desc)
+    # 最安値の購入履歴データ取得
     @lowest_purchase = @item.purchases.order(:unit_price).first
-    puts "セッションの確認#{session.inspect}"
   end
 
   private

--- a/app/javascript/controllers/compare_controller.js
+++ b/app/javascript/controllers/compare_controller.js
@@ -3,6 +3,12 @@ import { Controller } from "@hotwired/stimulus"
 
 // static targets = […]でJSで操作したいHTMLの要素を定義
 export default class extends Controller {
+
+// 画面読み込み時、JS実行（購入履歴からのデータ取得時をフォームに自動出力した際にJSが走らないため） 
+  connect() {
+    this.calculate()
+  }
+
   static targets = [
     "contentquantityA", "packquantityA", "priceA", "resultA",
     "contentquantityB", "packquantityB", "priceB", "resultB",

--- a/app/views/comparison/index.html.erb
+++ b/app/views/comparison/index.html.erb
@@ -1,40 +1,29 @@
-<!-- stimulusのコントローラー定義 -->
+<%# === 比較画面一覧 === %>
+<%# ─── stimulusのコントローラー定義 ─── %>
 <div data-controller="compare">
 
-  <!-- 比較入力エリア -->
+  <%# ─── 比較入力エリア ─── %>
   <div class="grid gap-8 relative">
 
-    <!-- 商品A -->
+    <%# ─── 商品A（内容量・パック数・価格のフォーム） ─── %>
     <div class="bg-white rounded-2xl shadow p-6">
       <h2 class="text-xl font-bold text-center mb-6">商品A</h2>
 
       <div class="space-y-4">
+      <%= form_with model: @purchase, url: "#", method: :post do |f| %>
         <div>
-          <label class="text-sm text-gray-500">内容量</label>
-          <input type="number"
-                  class="w-full mt-1 p-3 rounded-lg bg-gray-100 border-none focus:ring-2 focus:ring-green"
-                  placeholder="例：500"
-                  data-compare-target="contentquantityA"
-                  data-action="input->compare#calculate">
+          <%= f.label :content_quantity, class: "text-sm text-gray-500" %>
+          <%= f.number_field :content_quantity, placeholder: "例：500", class: "w-full mt-1 p-3 rounded-lg bg-gray-100 border-none focus:ring-2 focus:ring-green", data: {compare_target: "contentquantityA", action: "input->compare#calculate" } %>
         </div>
-
         <div>
-          <label class="text-sm text-gray-500">パック数</label>
-          <input type="number"
-                  class="w-full mt-1 p-3 rounded-lg bg-gray-100 border-none focus:ring-2 focus:ring-green"
-                  placeholder="例：3"
-                  data-compare-target="packquantityA"
-                  data-action="input->compare#calculate">
+          <%= f.label :pack_quantity, class: "text-sm text-gray-500" %>
+          <%= f.number_field :pack_quantity, placeholder: "例：3", class: "w-full mt-1 p-3 rounded-lg bg-gray-100 border-none focus:ring-2 focus:ring-green", data: {compare_target: "packquantityA", action: "input->compare#calculate" } %>
         </div>
-
         <div>
-          <label class="text-sm text-gray-500">価格</label>
-          <input type="number"
-                  class="w-full mt-1 p-3 rounded-lg bg-gray-100 border-none focus:ring-2 focus:ring-green"
-                  placeholder="例：598"
-                  data-compare-target="priceA"
-                  data-action="input->compare#calculate">
+          <%= f.label :price, class: "text-sm text-gray-500" %>
+          <%= f.number_field :price, placeholder: "例：598", class: "w-full mt-1 p-3 rounded-lg bg-gray-100 border-none focus:ring-2 focus:ring-green", data: {compare_target: "priceA", action: "input->compare#calculate" } %>
         </div>
+      <% end %>
         <div class="mt-4 p-4 bg-gray-50 rounded-xl text-center">
           <p class="text-sm text-gray-500">単価（税抜）</p>
           <p class="text-2xl font-bold text-gray-800">
@@ -45,7 +34,7 @@
       </div>
     </div>
 
-    <!-- VSバッジ -->
+    <%# ─── VSバッジ ─── %>
     <div class="relative">
       <div class="md:flex absolute inset-0 items-center justify-center pointer-events-none">
         <div class="bg-green text-white w-12 h-12 rounded-full flex items-center justify-center font-bold shadow">
@@ -54,7 +43,7 @@
       </div>
     </div>
 
-    <!-- 商品B -->
+    <%# ─── 商品B（内容量・パック数・価格のフォーム） ─── %>
     <div class="bg-white rounded-2xl shadow p-6">
       <h2 class="text-xl font-bold text-center mb-6">商品B</h2>
 
@@ -63,7 +52,7 @@
           <label class="text-sm text-gray-500">内容量</label>
           <input type="number"
                   class="w-full mt-1 p-3 rounded-lg bg-gray-100 border-none focus:ring-2 focus:ring-green"
-                  placeholder="例：500",
+                  placeholder="例：500"
                   data-compare-target="contentquantityB"
                   data-action="input->compare#calculate">
         </div>
@@ -94,7 +83,7 @@
       </div>
     </div>
   </div>
-  <!-- お得表示 -->
+  <%# ─── お得表示（stimulusより計算結果出力時のみ表示） ─── %>
   <div>
     <div class="bg-orange-100 text-orange-600 text-center py-4 rounded-xl font-semibold text-lg empty:hidden" " data-compare-target="compareResultItem"></div>
   </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,5 +1,5 @@
-
-<%# ── 商品名 ── %>
+<%# === 購入履歴一覧画面 === %>
+<%# ─── 商品名・カテゴリ名の表示 ─── %>
 <h1 class="text-xl font-bold mb-4">
   <%= @item.name %>
   <span class="text-xs font-medium text-green-700 bg-green-100 rounded-full px-2 py-0.5 ml-2 align-middle">
@@ -7,30 +7,40 @@
   </span>
 </h1>
 
-<%# ── 現在の最安値 ── %>
+<%# ─── 現在の最安値表示 ─── %>
 <% if @lowest_purchase.present? %>
   <div class="bg-white rounded-2xl shadow-md p-5 mb-7 relative overflow-hidden border-t-4 border-green">
     <div class="absolute inset-0 bg-gradient-to-br from-orange-50 to-white pointer-events-none"></div>
-    <div class="relative py-3">
-      <div class="absolute top-0 right-0 w-8 h-8 bg-orange-400 rounded-full flex items-center justify-center text-base shadow-md">
-        <span class="material-symbols-outlined text-20 text-white">crown</span>
+      <div class="relative py-3">
+        <div class="absolute top-0 right-0 w-8 h-8 bg-orange-400 rounded-full flex items-center justify-center text-base shadow-md">
+          <span class="material-symbols-outlined text-20 text-white">crown</span>
+        </div>
+        <p class="text-center text-xs text-gray-400 font-medium tracking-widest uppercase mb-4">現在の最安単価</p>
+        <p class="font-bold text-center text-xs text-gray-600 mb-4">1<%= @lowest_purchase.content_unit %>あたり
+          <span class="text-4xl text-green tracking-tight mb-4">
+            <%= @lowest_purchase.unit_price %><span class="text-xl ml-1">円</span>
+          </span>
+        </p>
+        <hr class="border-gray-200 mb-6">
+        <div class= "flex justify-center">
+          <%= link_to comparison_path(purchase_id: @lowest_purchase.id), class: "flex text-center justify-center gap-2 px-8 py-3 rounded-full border border-green text-green hover:bg-green hover:text-white" do %>
+            <span class="flex items-end justify-center gap-1">
+              <span class="material-symbols-outlined text-base">balance</span>
+              <span>この商品で比較します</span>
+            </span>
+          <% end %> 
+        </div>
       </div>
-      <p class="text-center text-xs text-gray-400 font-medium tracking-widest uppercase mb-4">現在の最安単価</p>
-      <p class="font-bold text-center text-xs text-gray-600 mb-1">1<%= @lowest_purchase.content_unit %>あたり
-        <span class="text-4xl text-green tracking-tight mb-4">
-          <%= @lowest_purchase.unit_price %><span class="text-xl ml-1">円</span>
-        </span>
-      </p>
-    </div>
   </div>
 <% end %>
 
-<%# ── 購入履歴 ── %>
+<%# ─── 商品の購入履歴件数 ─── %>
 <div class="flex items-baseline justify-between mb-3">
   <h2 class="text-sm font-bold text-gray-600 tracking-wide">購入履歴</h2>
   <span class="text-xs text-gray-400">全 <%= @purchases.size %> 件</span>
 </div>
 
+<%# ─── 購入履歴 ─── %>
 <% @purchases.each do |purchase| %>
   <%
     is_cheapest = @lowest_purchase.present? && purchase.id == @lowest_purchase.id
@@ -38,7 +48,7 @@
   %>
   <div class="bg-white rounded-2xl shadow-sm border border-gray-100 p-4 mb-3">
 
-    <%# ヘッダー行 %>
+    <%# ─── ヘッダー行（購入日・編集・削除）  ─── %>
     <div class="flex items-center justify-between mb-3">
       <div class="flex items-center gap-2">
         <span class="text-xs text-gray-400 font-medium tracking-wide"><%= purchase.purchased_on %></span>
@@ -54,7 +64,7 @@
       </div>
     </div>
 
-    <%# 詳細グリッド %>
+    <%# ─── 詳細（店舗名・ブランド・内容量・パック数・税率・金額・単価） ─── %>
     <div class="grid grid-cols-2 gap-x-4 gap-y-2.5 mb-3">
       <div>
         <p class="text-xs text-gray-400 mb-0.5">店舗名</p>
@@ -84,7 +94,7 @@
       </div>
     </div>
 
-    <hr class="border-gray-100 mb-3">
+    <hr class="border-gray-200 mb-3">
 
     <%# 単価 %>
     <div class="flex items-baseline justify-between">


### PR DESCRIPTION
### 概要
過去に登録した商品の購入履歴から商品を選択し、
比較フォームの入力値として反映できる機能を実装する。

### 実施内容
- 過去の購入履歴一覧より、比較画面に遷移するリンクを生成 
- 選択した購入履歴のデータを比較画面へ渡す処理を実装
- 渡されたデータを比較フォームの入力値として表示
- javascriptが挙動しないのを修正
### 関連Issue
Closes #111 