### PR TITLE
単価が異なる原因を修正

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -15,10 +15,10 @@ class ItemsController < ApplicationController
     puts "パラメーター確認#{params.inspect}"
     purchase_params = if params[:purchase_a].present?
       puts "purchase_aは存在する"
-      params[:purchase_a]&.permit(:content_quantity, :pack_quantity, :price)
+      params[:purchase_a]&.permit(:content_quantity, :pack_quantity, :price, :tax_rate)
     elsif params[:purchase_b].present?
       puts "purchase_bは存在する"
-      params[:purchase_b]&.permit(:content_quantity, :pack_quantity, :price)
+      params[:purchase_b]&.permit(:content_quantity, :pack_quantity, :price, :tax_rate)
     else
       puts "purchase_aとbどちらも存在しない"
     end
@@ -27,7 +27,8 @@ class ItemsController < ApplicationController
       puts "purchase_paramsは存在してフォームにデータが入る"
       @form = ItemStep1Form.new(content_quantity: purchase_params[:content_quantity],
                                 pack_quantity: purchase_params[:pack_quantity],
-                                price: purchase_params[:price]
+                                price: purchase_params[:price],
+                                tax_rate: purchase_params[:tax_rate]
       )
     else
       puts "purchase_paramsは存在せず、フォームは空白"

--- a/app/javascript/controllers/compare_controller.js
+++ b/app/javascript/controllers/compare_controller.js
@@ -10,37 +10,43 @@ export default class extends Controller {
   }
 
   static targets = [
-    "contentquantityA", "packquantityA", "priceA", "resultA",
-    "contentquantityB", "packquantityB", "priceB", "resultB",
+    "contentquantityA", "packquantityA", "priceA", "taxrateA", "resultA",
+    "contentquantityB", "packquantityB", "priceB", "taxrateB", "resultB",
     "compareResultItem",
     "cardA", "cardB", "badgeA", "badgeB"
   ]
 
   // A・B両方の単価を計算後、比較処理を実行する
   calculate() {
+    const taxrateA = this.element.querySelector('input[name="purchase_a[tax_rate]"]:checked')?.value ?? 0
+    const taxrateB = this.element.querySelector('input[name="purchase_b[tax_rate]"]:checked')?.value ?? 0
+    
     this.resultA.textContent = this.calcUnitPrice(
       this.contentquantityATarget.value,
       this.packquantityATarget.value,
-      this.priceATarget.value
+      this.priceATarget.value,
+      taxrateA
     )
     this.resultB.textContent = this.calcUnitPrice(
       this.contentquantityBTarget.value,
       this.packquantityBTarget.value,
-      this.priceBTarget.value
+      this.priceBTarget.value,
+      taxrateB
     )
     this.compare()
 
   }
   // 単価 = 価格 ÷ 内容量 ÷ 個数 で算出
   // 未入力・0の項目がある場合は計算不能のため"---"を返す
-  calcUnitPrice(contentquantity, packquantity, price){
+  calcUnitPrice(contentquantity, packquantity, price, taxrate){
     const c = parseFloat(contentquantity)
     const q = parseFloat(packquantity)
     const p = parseFloat(price)
+    const t = parseFloat(taxrate)
 
-    if (!p || !c || !q) return "---"
+    if (!p || !c || !q || isNaN(t)) return "---"
 
-    return (p / c / q).toFixed(2)
+    return (p / (1 + t / 100) / c / q).toFixed(2)
   }
 
   // A・Bの単価を比較し差額を表示する

--- a/app/views/comparison/index.html.erb
+++ b/app/views/comparison/index.html.erb
@@ -31,6 +31,33 @@
             <%= f.number_field :price, placeholder: "例：598", class: "w-full p-2 bg-transparent outline-none text-gray-700 text-sm", data: {compare_target: "priceA", action: "input->compare#calculate" } %>
           </div>
         </div>
+        <div>
+          <%= f.label :tax_rate, "税率", class: "text-gray-500" %>
+          <div class="flex mt-1 bg-gray-100 dark:bg-gray-800 p-1 rounded-xl">
+
+            <%# 税抜 (値: 0) %>
+            <div class="flex-1">
+              <%= f.radio_button :tax_rate, 0, checked: true, class: "hidden peer", id: "tax-none-a", data: {action: "change->compare#calculate"} %>
+              <%= f.label :tax_rate, "税抜", value: 0, for: "tax-none-a", 
+                class: "block text-center py-2 text-sm font-medium text-gray-500 dark:text-gray-400 rounded-lg cursor-pointer transition-all peer-checked:bg-white peer-checked:text-[#6abf3b] peer-checked:shadow-sm" %>
+            </div>
+
+            <%# 8% (値: 8) %>
+            <div class="flex-1">
+              <%= f.radio_button :tax_rate, 8, class: "hidden peer", id: "tax-8-a", data: {action: "change->compare#calculate"}  %>
+              <%= f.label :tax_rate, "8%", value: 8, for: "tax-8-a", 
+                class: "block text-center py-2 text-sm font-medium text-gray-500 dark:text-gray-400 rounded-lg cursor-pointer transition-all peer-checked:bg-white peer-checked:text-[#6abf3b] peer-checked:shadow-sm" %>
+            </div>
+
+            <%# 10% (値: 10) %>
+            <div class="flex-1">
+              <%= f.radio_button :tax_rate, 10, class: "hidden peer", id: "tax-10-a", data: {action: "change->compare#calculate"}  %>
+              <%= f.label :tax_rate, "10%", value: 10, for: "tax-10-a", 
+                class: "block text-center py-2 text-sm font-medium text-gray-500 dark:text-gray-400 rounded-lg cursor-pointer transition-all peer-checked:bg-white peer-checked:text-[#6abf3b] peer-checked:shadow-sm" %>
+            </div>
+          </div>
+        </div>
+
         <div class="mt-4 p-4 bg-gray-50 rounded-xl text-center">
           <p class="text-sm text-gray-500">単価（税抜）</p>
           <p class="text-2xl font-bold text-gray-800">
@@ -69,6 +96,33 @@
             <%= f.number_field :price, placeholder: "例：598", class: "w-full p-2 bg-transparent outline-none text-gray-700 text-sm", data: {compare_target: "priceB", action: "input->compare#calculate" } %>
           </div>
         </div>
+        <div>
+          <%= f.label :tax_rate, "税率", class: "text-gray-500" %>
+          <div class="flex mt-1 bg-gray-100 dark:bg-gray-800 p-1 rounded-xl">
+
+            <%# 税抜 (値: 0) %>
+            <div class="flex-1">
+              <%= f.radio_button :tax_rate, 0, checked: true, class: "hidden peer", id: "tax-none-b", data: {action: "change->compare#calculate"} %>
+              <%= f.label :tax_rate, "税抜", value: 0, for: "tax-none-b", 
+                class: "block text-center py-2 text-sm font-medium text-gray-500 dark:text-gray-400 rounded-lg cursor-pointer transition-all peer-checked:bg-white peer-checked:text-[#6abf3b] peer-checked:shadow-sm" %>
+            </div>
+
+            <%# 8% (値: 8) %>
+            <div class="flex-1">
+              <%= f.radio_button :tax_rate, 8, class: "hidden peer", id: "tax-8-b", data: {action: "change->compare#calculate"} %>
+              <%= f.label :tax_rate, "8%", value: 8, for: "tax-8-b", 
+                class: "block text-center py-2 text-sm font-medium text-gray-500 dark:text-gray-400 rounded-lg cursor-pointer transition-all peer-checked:bg-white peer-checked:text-[#6abf3b] peer-checked:shadow-sm" %>
+            </div>
+
+            <%# 10% (値: 10) %>
+            <div class="flex-1">
+              <%= f.radio_button :tax_rate, 10, class: "hidden peer", id: "tax-10-b", data: {action: "change->compare#calculate"} %>
+              <%= f.label :tax_rate, "10%", value: 10, for: "tax-10-b", 
+                class: "block text-center py-2 text-sm font-medium text-gray-500 dark:text-gray-400 rounded-lg cursor-pointer transition-all peer-checked:bg-white peer-checked:text-[#6abf3b] peer-checked:shadow-sm" %>
+            </div>
+          </div>
+        </div>
+
         <div class="mt-4 p-4 bg-gray-50 rounded-xl text-center">
           <p class="text-sm text-gray-500">単価（税抜）</p>
           <p class="text-2xl font-bold text-gray-800">


### PR DESCRIPTION
### 概要
最安値の表示金額が比較画面時と異なるエラーを修正
### 実施内容
- 単価統一のために比較画面に税計算を実装
- 比較画面の税のラジオボタ実装
- 税を比較画面から商品登録画面にデータを移行できるようコントローラー修正
### 関連Issue
Closes #117 