### PR TITLE
ヘッダータイトルと戻るボタンの動的出力

### DIFF
--- a/app/views/comparison/index.html.erb
+++ b/app/views/comparison/index.html.erb
@@ -1,4 +1,10 @@
 <%# === 比較画面一覧 === %>
+<% content_for :arrow_back do %>
+  arrow_back
+<% end %>
+<% content_for :title do %>
+  VS どちらがお得？
+<% end %>
 <%# ─── stimulusのコントローラー定義 ─── %>
 <div data-controller="compare">
 

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -1,3 +1,6 @@
+<% content_for :title do %>
+  底値商品一覧
+<% end %>
 <div class="space-y-4">
     <% @items.each do |item| %>
       <% cheapest_purchase = item.purchases.min_by { |p| p.unit_price } %>

--- a/app/views/items/new_step1.html.erb
+++ b/app/views/items/new_step1.html.erb
@@ -1,4 +1,11 @@
 <!-- 商品新規登録画面 2-1 -->
+<% content_for :arrow_back do %>
+  arrow_back
+<% end %>
+<% content_for :title do %>
+  商品登録
+<% end %>
+
 <div class"flex flex-col md:flex-row items-center justify-center gap-6 p-4">
   <div class="bg-white rounded-3xl shadow-xl w-full px-7 py-8">
     <h1 class= "text-center text-2xl font-bold text-gray-800 mb-6">商品情報の登録</h1>

--- a/app/views/items/new_step2.html.erb
+++ b/app/views/items/new_step2.html.erb
@@ -1,4 +1,10 @@
 <!-- 商品新規登録画面 2-2 -->
+<% content_for :arrow_back do %>
+  arrow_back
+<% end %>
+<% content_for :title do %>
+  商品登録
+<% end %>
 <%= render 'shared/error_messages', object: @form %>
 <div class= "bg-white rounded-xl p-4 shadow mb-6 ">
   <div class="flex items-center justify-between border-b border-gray-100 pb-2 mb-4">

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,4 +1,11 @@
 <%# === 購入履歴一覧画面 === %>
+<% content_for :arrow_back do %>
+  arrow_back
+<% end %>
+<% content_for :title do %>
+  購入履歴一覧
+<% end %>
+
 <%# ─── 商品名・カテゴリ名の表示 ─── %>
 <h1 class="text-xl font-bold mb-4">
   <%= @item.name %>

--- a/app/views/purchases/edit.html.erb
+++ b/app/views/purchases/edit.html.erb
@@ -1,4 +1,7 @@
 <!-- 商品編集画面 -->
+<% content_for :title do %>
+  商品情報の編集
+<% end %>
 <div class"flex flex-col md:flex-row items-center justify-center gap-6 p-4">
   <div class="bg-white rounded-3xl shadow-xl w-full px-7 py-8">
     <h1 class="text-center text-2xl font-bold text-gray-800 mb-6">商品情報の更新</h1>

--- a/app/views/setting/index.html.erb
+++ b/app/views/setting/index.html.erb
@@ -1,3 +1,6 @@
+<% content_for :title do %>
+  設定
+<% end %>
 <h1>設定画面</h1>
 <div class= p-2>
   <%= button_to "ログアウトする", destroy_user_session_path, method: :delete, class: "inline-block bg-green text-white px-6 py-2 rounded hover:bg-green-600 focus:outline-none focus:ring-green-400" %>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -18,7 +18,7 @@
       <div class="flex flex-col items-center cursor-not-allowed relative group">
         <span class="material-symbols-outlined text-28 group-hover:invisible">photo_camera</span>
         <span class="text-xs mt-1 group-hover:invisible"><%= t('footer.photo') %></span>
-        <span class="text-[10px] absolute bottom-1 bg-gray-200 px-1 rounded invisible group-hover:visible">coming soon</span>
+        <span class="text-[10px] absolute bottom-1 text-center bg-gray-200 px-1 rounded invisible group-hover:visible">coming soon</span>
       </div>
     <% end %>
     

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,8 +1,14 @@
 <header class="fixed top-0 left-0 w-full bg-green border-b border-gray-200 z-50">
-  <nav class="flex justify-around items-center h-16">
-    <!-- ヘッダーの題名を選択するとホーム画面（商品一覧画面）に戻るよう遷移 -->
-    <%= link_to items_path, class: "flex flex-col items-center text-white" do %>
-      <span class="text-2xl font-bold mt-3">SokoNote</span>
-    <% end %>
+  <nav class="flex items-center h-16 px-8">
+    <div class="flex items-center justify-start w-10 material-symbols-outlined mt-3 text-white">
+      <%= link_to yield(:arrow_back).presence || "", :back %> 
+    </div>
+    <div class="flex-1 text-center text-white font-bold text-2xl mt-3">
+      <%= yield(:title).presence || link_to("SokoNote", root_path) %>
+    </div>
+    <div class="flex items-center justify-end w-10 text-white mt-3 cursor-not-allowed group">
+      <span class="material-symbols-outlined group-hover:invisible">density_medium</span>
+      <span class="absolute bg-dark-gray rounded px-1 text-xs right-2 md:text-xl invisible group-hover:visible">coming soon</span>
+    </div>
   </nav>
 </header>

--- a/app/views/users/passwords/new.html.erb
+++ b/app/views/users/passwords/new.html.erb
@@ -1,4 +1,7 @@
 <!-- パスワードリセット画面 -->
+<% content_for :arrow_back do %>
+  arrow_back
+<% end %>
 <div class="flex flex-col md:flex-row items-center justify-center gap-6 p-4">
   <div class="bg-white rounded-3xl shadow-xl w-full px-7 py-8">
     <h2 class="text-center text-2xl font-bold text-gray-800 mb-6"><%= t("devise.passwords.new.forgot_your_password") %></h2>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -1,4 +1,7 @@
 <!-- アカウント登録画面 -->
+<% content_for :arrow_back do %>
+  arrow_back
+<% end %>
 <div class="flex flex-col md:flex-row items-center justify-center gap-6 p-4">
   <div class="bg-white rounded-3xl shadow-xl w-full px-7 py-8">
     <h2 class="text-center text-2xl font-bold text-gray-800 mb-6"><%= t("devise.registrations.new.sign_up") %></h2>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,4 +1,7 @@
 <!-- ログイン画面 -->
+<% content_for :arrow_back do %>
+  arrow_back
+<% end %>
 <div class="flex flex-col md:flex-row items-center justify-center gap-6 p-4"> 
   <div class="bg-white rounded-3xl shadow-xl w-full px-7 py-8">
     <h2 class="text-center text-2xl font-bold text-gray-800 mb-6"><%= t("devise.sessions.new.sign_in") %></h2>


### PR DESCRIPTION
### 概要
ヘッダーに表示するタイトルと戻るボタンを、各ページごとに動的に変更できるようにする。
### 実施内容
- ログイン前は"SokoNote"とし、リンク付きで生成
- ログイン後は各画面に応じてタイトル生成
- 必要な画面において戻るボタン実装 
- 左右対称にするため、本リリース予定のハンバーガーメニューを形だけ実装
### 関連Issue
Closes #119 