### PR TITLE
同一メールアドレス時のフラッシュメッセージ改善

### DIFF
--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -28,6 +28,12 @@ ja:
     models:
       user:
         other: ユーザー
+    errors:
+      models:
+        user:
+          attributes:
+            email:
+              taken: "は現在使用できません"
   devise:
     confirmations:
       confirmed: メールアドレスが確認できました。


### PR DESCRIPTION
### 概要
ユーザー登録時のフラッシュメッセージ「メールアドレスはすでに存在します」の変更
### 実施内容
- ja.ymlの追記「は現在使用できません」
### 関連Issue
Closes #133 