### PR TITLE
カテゴリの登録（new、create）の実装

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -31,13 +31,6 @@
   display: contents;
 }
 
-/* 全要素にフォーカスを当てる */
-@layer base {
-  :focus-visible {
-    @apply outline-none ring-black ring-2 ring-offset-2;
-  }
-}
-
 /* 自分の名前をつけた変数にスタイルを当てる */
 @layer components { 
   /* ボタン・ボタン風リンクなどの押下できるcardに適用 */
@@ -45,7 +38,7 @@
     @apply cursor-pointer shadow-md shadow-black/40 hover:-translate-y-0.5 hover:shadow-lg active:translate-y-1 active:shadow-sm transition-all;
   }
   
-  /* 編集・削除を表示させるスワイプ用のcardの外側に適用*/
+  /* 編集・削除を表示させるスワイプ用のcardの外側に適用 */
   .swipe-card {
     @apply relative overflow-hidden rounded-2xl shadow-md;
   }

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -4,9 +4,17 @@ class CategoriesController < ApplicationController
   end
 
   def new
+    @category = current_user.categories.new()
   end
 
   def create
+    @category = current_user.categories.new(category_params)
+    if @category.save
+      redirect_to categories_path, success: "カテゴリを登録しました"
+    else
+      flash.now[:error] = "カテゴリ登録に失敗しました"
+      render :new, status: :unprocessable_entity
+    end
   end
 
   def show
@@ -19,5 +27,11 @@ class CategoriesController < ApplicationController
   end
 
   def destroy
+  end
+
+  private
+
+  def category_params
+    params.require(:category).permit(:name)
   end
 end

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -38,7 +38,7 @@
 </div>
 <%# 商品登録ボタン（FAB） %>
 <div class="fixed bottom-28 left-0 right-0 mx-auto max-w-xl px-6 flex justify-end z-25">
-  <%= link_to "#", class: "card bg-primary text-white px-6 py-4 rounded-full flex items-center font-bold", data: { controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" } do %>
+  <%= link_to new_category_path, class: "card bg-primary text-white px-6 py-4 rounded-full flex items-center font-bold", data: { controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" } do %>
     <span class="text-lg">カテゴリ追加</span>
     <span class="material-symbols-outlined">add</span>
   <% end %>

--- a/app/views/categories/new.html.erb
+++ b/app/views/categories/new.html.erb
@@ -1,0 +1,18 @@
+<!-- カテゴリ新規登録 -->
+<% content_for :arrow_back do %>
+  arrow_back
+<% end %>
+<% content_for :title do %>
+  カテゴリ登録
+<% end %>
+
+<%= form_with model: @category do |f| %>
+  <%= render 'shared/error_messages', object: f.object %>
+  <div class ="mb-10">
+    <%= f.label :name, class: "block text-black font-bold mb-2"%>
+    <div class="flex border border-light-gray rounded-xl px-3 py-3 bg-white focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition">
+      <%= f.text_field :name, placeholder: "例：飲料 / 日用品", autocomplete: "off", class: "flex-auto outline-none text-black bg-transparent placeholder-gray" %>
+    </div>
+  </div>
+  <%= f.submit "この内容で登録する", class: "card w-full bg-primary tracking-widest text-white px-6 py-4 rounded-full flex items-center justify-center font-bold no-underline", data: { controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" } %>
+<% end %>


### PR DESCRIPTION
### 関連ISSUE
---
close #155 

### 変更内容
---
- カテゴリ単体での登録を行えるように実装しました。
- 登録後はカテゴリ一覧に遷移し、成功メッセージを表示します。
- 失敗時はその場でエラーが出力されます。

### 動作確認
---
- 設定画面から、カテゴリ管理へ移動
- カテゴリの一覧が出てくるので、カテゴリ追加を選択
- 追加したいカテゴリ名を選択し登録
- 登録後、カテゴリ一覧画面へ遷移される

### 補足・レビュアーへのメモ
---