### PR TITLE
カテゴリの削除機能実装

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -32,6 +32,9 @@ class CategoriesController < ApplicationController
   end
 
   def destroy
+    @category = current_user.categories.find(params[:id])
+    @category.destroy
+    redirect_to categories_path, success: "カテゴリを削除しました"
   end
 
   private

--- a/app/views/categories/edit.html.erb
+++ b/app/views/categories/edit.html.erb
@@ -14,5 +14,5 @@
       <%= f.text_field :name, placeholder: "例：飲料 / 日用品", autocomplete: "off", class: "flex-auto outline-none text-black bg-transparent placeholder-gray" %>
     </div>
   </div>
-  <%= f.submit "この内容で登録する", class: "card w-full bg-primary tracking-widest text-white px-6 py-4 rounded-full flex items-center justify-center font-bold no-underline", data: { controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" } %>
+  <%= f.submit "この内容で更新する", class: "card w-full bg-primary tracking-widest text-white px-6 py-4 rounded-full flex items-center justify-center font-bold no-underline", data: { controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" } %>
 <% end %>

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -27,7 +27,7 @@
               class: "flex items-center justify-center w-11
                       bg-blue-400 text-white text-xs font-medium self-stretch" %>
 
-        <%= link_to "削除", "#",
+        <%= link_to "削除", category_path(category),
               data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" },
               class: "flex items-center justify-center w-11
                       bg-red-400 text-white text-xs font-medium


### PR DESCRIPTION
### 関連ISSUE
---
close #157
子ISSUE全て終了
親ISSUEも閉じる
close #148 

### 変更内容
---
- カテゴリ登録一覧の削除機能よりデータの削除を実装しました。
- 削除後はメッセージが出力されます。

### 動作確認
---
- 設定画面より、カテゴリマストを選択
- カテゴリ一覧が出力されるので削除したいカテゴリにマウスを当てると削除ボタンが表示
- 削除ボタンを押すと確認ダイアログが表示され、削除され、カテゴリ一覧に戻ります。

### 補足・レビュアーへのメモ
---