### PR TITLE
【StoreモデルCRUD】②店舗名の新規登録機能を実装する

### DIFF
--- a/app/controllers/stores_controller.rb
+++ b/app/controllers/stores_controller.rb
@@ -4,9 +4,17 @@ class StoresController < ApplicationController
   end
 
   def new
+    @store = current_user.stores.new()
   end
 
   def create
+    @store = current_user.stores.new(store_params)
+    if @store.save
+      redirect_to stores_path, success: "店舗を登録しました"
+    else
+      flash.now[:error] = "店舗登録に失敗しました"
+      render :new, status: :unprocessable_entity
+    end
   end
 
   def edit
@@ -16,5 +24,11 @@ class StoresController < ApplicationController
   end
 
   def destroy
+  end
+
+  private
+
+  def store_params
+    params.require(:store).permit(:name)
   end
 end

--- a/app/views/stores/index.html.erb
+++ b/app/views/stores/index.html.erb
@@ -32,7 +32,7 @@
 <%# 商品登録ボタン（FAB） %>
 <div class="fixed bottom-28 left-0 right-0 mx-auto max-w-xl px-6 flex justify-end z-25">
   <%= link_to new_store_path, class: "card bg-primary text-white px-6 py-4 rounded-full flex items-center font-bold", data: { controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" } do %>
-    <span class="text-lg">カテゴリ追加</span>
+    <span class="text-lg">店舗追加</span>
     <span class="material-symbols-outlined">add</span>
   <% end %>
 </div>

--- a/app/views/stores/index.html.erb
+++ b/app/views/stores/index.html.erb
@@ -31,7 +31,7 @@
 </div>
 <%# 商品登録ボタン（FAB） %>
 <div class="fixed bottom-28 left-0 right-0 mx-auto max-w-xl px-6 flex justify-end z-25">
-  <%= link_to "#", class: "card bg-primary text-white px-6 py-4 rounded-full flex items-center font-bold", data: { controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" } do %>
+  <%= link_to new_store_path, class: "card bg-primary text-white px-6 py-4 rounded-full flex items-center font-bold", data: { controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" } do %>
     <span class="text-lg">カテゴリ追加</span>
     <span class="material-symbols-outlined">add</span>
   <% end %>

--- a/app/views/stores/new.html.erb
+++ b/app/views/stores/new.html.erb
@@ -1,0 +1,18 @@
+<!-- 店舗新規登録 -->
+<% content_for :arrow_back do %>
+  arrow_back
+<% end %>
+<% content_for :title do %>
+  店舗登録
+<% end %>
+
+<%= form_with model: @store do |f| %>
+  <%= render 'shared/error_messages', object: f.object %>
+  <div class ="mb-10">
+    <%= f.label :name, class: "block text-black font-bold mb-2"%>
+    <div class="flex border border-light-gray rounded-xl px-3 py-3 bg-white focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition">
+      <%= f.text_field :name, placeholder: "例：〇〇スーパー〇〇店 / 〇〇薬局", autocomplete: "off", class: "flex-auto outline-none text-black bg-transparent placeholder-gray" %>
+    </div>
+  </div>
+  <%= f.submit "この内容で登録する", class: "card w-full bg-primary tracking-widest text-white px-6 py-4 rounded-full flex items-center justify-center font-bold no-underline", data: { controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" } %>
+<% end %>


### PR DESCRIPTION
### 関連ISSUE
---
close #159 


### 変更内容
---
- 店舗の新規登録を実装（newアクション・createアクション）しました。
- 登録成功時、店舗一覧にリダイレクトされ、成功メッセージが表示されます。
- 登録失敗時、その場にとどまり、エラーメッセージが表示されます。

### 動作確認
---
- 店舗一覧画面から、店舗追加を選択すると新規登録画面へ遷移。
- 店舗名を登録すると、店舗一覧画面へリダイレクトされる。

### 補足・レビュアーへのメモ
---