### PR TITLE
店舗マスタの更新機能実装

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -26,7 +26,7 @@ class CategoriesController < ApplicationController
     if @category.update(category_params)
       redirect_to categories_path, success: "カテゴリを更新しました"
     else
-      flash.now[:error] = "カテゴリの編集に失敗しました"
+      flash.now[:error] = "カテゴリの更新に失敗しました"
       render :edit, status: :unprocessable_entity
     end
   end

--- a/app/controllers/stores_controller.rb
+++ b/app/controllers/stores_controller.rb
@@ -18,9 +18,17 @@ class StoresController < ApplicationController
   end
 
   def edit
+    @store = current_user.stores.find(params[:id])
   end
 
   def update
+    @store = current_user.stores.find(params[:id])
+    if @store.update(store_params)
+      redirect_to stores_path, success: "店舗を更新しました"
+    else
+      flash.now[:error] = "店舗の更新に失敗しました。"
+      render :edit, status: :unprocessable_entity
+    end
   end
 
   def destroy

--- a/app/views/stores/edit.html.erb
+++ b/app/views/stores/edit.html.erb
@@ -1,0 +1,18 @@
+<!-- 店舗新規登録 -->
+<% content_for :arrow_back do %>
+  arrow_back
+<% end %>
+<% content_for :title do %>
+  店舗編集
+<% end %>
+
+<%= form_with model: @store do |f| %>
+  <%= render 'shared/error_messages', object: f.object %>
+  <div class ="mb-10">
+    <%= f.label :name, class: "block text-black font-bold mb-2"%>
+    <div class="flex border border-light-gray rounded-xl px-3 py-3 bg-white focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition">
+      <%= f.text_field :name, placeholder: "例：〇〇スーパー〇〇店 / 〇〇薬局", autocomplete: "off", class: "flex-auto outline-none text-black bg-transparent placeholder-gray" %>
+    </div>
+  </div>
+  <%= f.submit "この内容で更新する", class: "card w-full bg-primary tracking-widest text-white px-6 py-4 rounded-full flex items-center justify-center font-bold no-underline", data: { controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" } %>
+<% end %>

--- a/app/views/stores/index.html.erb
+++ b/app/views/stores/index.html.erb
@@ -23,7 +23,7 @@
       <%# アクションボタン %>
       <div class="swipe-actions" data-swipe-target="actions" style="transform: translateX(100%);">
 
-        <%= link_to "編集", "#", class: "flex items-center justify-center w-11 bg-blue-400 text-white text-xs font-medium self-stretch" %>
+        <%= link_to "編集", edit_store_path(store), class: "flex items-center justify-center w-11 bg-blue-400 text-white text-xs font-medium self-stretch" %>
         <%= link_to "削除", "#", data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" }, class: "flex items-center justify-center w-11 bg-red-400 text-white text-xs font-medium border-none cursor-pointer h-full" %>
       </div>
     </div>


### PR DESCRIPTION
### 関連ISSUE
---
close #160

### 変更内容
---
- 店舗マスタの更新機能（editアクション・updateアクション）を実装しました。
- 更新後、店舗一覧画面にリダイレクトされ、成功メッセージが表示されます。
- 更新失敗時、その画面のままエラーメッセージが表示されます。
### 動作確認
---
- 店舗マスタの各店舗名を選択すると、編集ボタンが表示
- 編集ボタンを選択し、編集画面に遷移
- "この内容で更新する”ボタンを選択すると更新され、店舗一覧画面へリダイレクトされます。

### 補足・レビュアーへのメモ
---