### PR TITLE
【StoreモデルCRUD】④店舗名の削除機能を実装する

### DIFF
--- a/app/controllers/stores_controller.rb
+++ b/app/controllers/stores_controller.rb
@@ -32,6 +32,9 @@ class StoresController < ApplicationController
   end
 
   def destroy
+    @store = current_user.stores.find(params[:id])
+    @store.destroy
+    redirect_to stores_path, success: "店舗を削除しました"
   end
 
   private

--- a/app/views/stores/index.html.erb
+++ b/app/views/stores/index.html.erb
@@ -24,7 +24,7 @@
       <div class="swipe-actions" data-swipe-target="actions" style="transform: translateX(100%);">
 
         <%= link_to "編集", edit_store_path(store), class: "flex items-center justify-center w-11 bg-blue-400 text-white text-xs font-medium self-stretch" %>
-        <%= link_to "削除", "#", data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" }, class: "flex items-center justify-center w-11 bg-red-400 text-white text-xs font-medium border-none cursor-pointer h-full" %>
+        <%= link_to "削除", store_path(store), data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" }, class: "flex items-center justify-center w-11 bg-red-400 text-white text-xs font-medium border-none cursor-pointer h-full" %>
       </div>
     </div>
   <% end %>


### PR DESCRIPTION
### 関連ISSUE
---
close #161 
子ISSUEを全て終了させたので親ISSUEもcloseする
close #149

### 変更内容
---
- 店舗の削除機能を実装しました。
- 店舗一覧から削除ボタンを押すと、確認ダイアログが表示されます
- 確認ダイアログではいにすすむと、店舗一覧にリダイレクトされ成功メッセージが表示されます。

### 動作確認
---
- 店舗一覧から、削除ボタンを選択
- 確認ダイアログを選択すると、店舗一覧にリダイレクトされ、選択データが削除されます。

### 補足・レビュアーへのメモ
---