### PR TITLE
内容量単位の一覧機能実装

### DIFF
--- a/app/controllers/content_units_controller.rb
+++ b/app/controllers/content_units_controller.rb
@@ -1,0 +1,5 @@
+class ContentUnitsController < ApplicationController
+  def index
+    @content_units = current_user.content_units.order(:name)
+  end
+end

--- a/app/helpers/content_units_helper.rb
+++ b/app/helpers/content_units_helper.rb
@@ -1,0 +1,2 @@
+module ContentUnitsHelper
+end

--- a/app/views/content_units/index.html.erb
+++ b/app/views/content_units/index.html.erb
@@ -1,0 +1,46 @@
+<%# ヘッダーを動的表示 %>
+<% content_for :arrow_back do %>
+  arrow_back
+<% end %>
+<% content_for :title do %>
+  内容量単位マスタ
+<% end %>
+
+<div class="space-y-4">
+  <% @content_units.each do |content_unit| %>
+    <div class="swipe-card" data-controller="swipe" data-action="touchstart->swipe#touchstart touchend->swipe#touchend touchstart@document->swipe#outsideClick">
+
+      <%# カテゴリ名：常に左端に固定表示 %>
+      <div class="absolute top-0 left-0 bottom-0 flex items-center px-5 z-10">
+        <span class="text-sm font-bold text-gray-800"><%= content_unit.name %></span>
+      </div>
+
+      <%# カードリンク（スライドする層）：右側に配置 %>
+      <div class="swipe-inner" data-swipe-target="inner">
+        <span class="material-symbols-outlined text-gray-300 text-sm">keyboard_double_arrow_right</span>
+      </div>
+
+      <%# アクションボタン %>
+      <div class="swipe-actions" data-swipe-target="actions" style="transform: translateX(100%);">
+
+        <%= link_to "編集", "#",
+              class: "flex items-center justify-center w-11
+                      bg-blue-400 text-white text-xs font-medium self-stretch" %>
+
+        <%= link_to "削除", "#",
+              data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" },
+              class: "flex items-center justify-center w-11
+                      bg-red-400 text-white text-xs font-medium
+                      border-none cursor-pointer h-full" %>
+      </div>
+    </div>
+  <% end %>
+</div>
+<%# 商品登録ボタン（FAB） %>
+<div class="fixed bottom-28 left-0 right-0 mx-auto max-w-xl px-6 flex justify-end z-25">
+  <%= link_to "#", class: "card bg-primary text-white px-6 py-4 rounded-full flex items-center font-bold", data: { controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" } do %>
+    <span class="text-lg">カテゴリ追加</span>
+    <span class="material-symbols-outlined">add</span>
+  <% end %>
+</div>
+

--- a/app/views/setting/index.html.erb
+++ b/app/views/setting/index.html.erb
@@ -36,11 +36,20 @@
       <% end %>
       <hr class="border-light-gray">
       <!-- 店舗マスタ -->
-      <%= link_to stores_path, class: "card flex items-center gap-4 p-4 rounded-b-2xl hover:bg-light-gray transition", data: { controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" } do %>
+      <%= link_to stores_path, class: "card shadow-none flex items-center gap-4 p-4 hover:bg-light-gray hover:shadow-lg active:shadow-sm transition", data: { controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" } do %>
         <div class="w-10 h-10 rounded-full bg-primary/20 flex items-center justify-center text-primary">
           <span class="material-symbols-outlined text-xl">privacy_tip</span>
         </div>
         <p class="flex-1 font-bold text-text-base text-sm">店舗管理</p>
+        <span class="material-symbols-outlined text-middle-gray">chevron_right</span>
+      <% end %>
+      <hr class="border-light-gray">
+      <!-- 内容量単価マスタ -->
+      <%= link_to content_units_path, class: "card flex items-center gap-4 p-4 rounded-b-2xl hover:bg-light-gray transition", data: { controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" } do %>
+        <div class="w-10 h-10 rounded-full bg-primary/20 flex items-center justify-center text-primary">
+          <span class="material-symbols-outlined text-xl">speed</span>
+        </div>
+        <p class="flex-1 font-bold text-text-base text-sm">内容量単位管理</p>
         <span class="material-symbols-outlined text-middle-gray">chevron_right</span>
       <% end %>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,9 @@ Rails.application.routes.draw do
   # 店舗一覧・登録・編集・削除
   resources :stores, except: [ :show ]
 
+  # 内容量単位一覧・登録・編集・削除
+  resources :content_units, except: [ :show ]
+
   # 商品一覧・登録（ウィザード形式 / 商品もカテゴリも新しく作る場合）
   # step1：基本情報入力, step2：詳細入力, session：基本情報入力値の一時保持
   resources :items do

--- a/spec/helpers/content_units_helper_spec.rb
+++ b/spec/helpers/content_units_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the ContentUnitsHelper. For example:
+#
+# describe ContentUnitsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe ContentUnitsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/content_units_spec.rb
+++ b/spec/requests/content_units_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "ContentUnits", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end


### PR DESCRIPTION
---
close #211 

### 変更内容
---
- 内容量単位一覧ページ（index）を実装しました。
- ContentUnitController に index アクションを追加しました。
- ログイン中ユーザーに紐づく内容量単位を取得して表示しました。
- 内容量単位一覧ページのビューを作成しました。
- 設定画面から内容量単位一覧ページへ遷移するリンクを追加しました。

### 動作確認
---
- ログイン状態で設定画面から内容量単位一覧ページへ遷移できること
- ログイン中ユーザーの内容量単位のみ一覧表示されること
- 内容量単位が0件の場合でも画面が正常に表示されること

### 補足・レビュアーへのメモ
---