### PR TITLE
内容量単位の新規登録機能を実装

### DIFF
--- a/app/controllers/content_units_controller.rb
+++ b/app/controllers/content_units_controller.rb
@@ -2,4 +2,24 @@ class ContentUnitsController < ApplicationController
   def index
     @content_units = current_user.content_units.order(:name)
   end
+
+  def new
+    @content_unit = current_user.content_units.new()
+  end
+
+  def create
+    @content_unit = current_user.content_units.new(content_unit_params)
+    if @content_unit.save
+      redirect_to content_units_path, success: "内容量単位を登録しました"
+    else
+      flash.now[:error] = "内容量単位登録に失敗しました"
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def content_unit_params
+    params.require(:content_unit).permit(:name)
+  end
 end

--- a/app/views/content_units/index.html.erb
+++ b/app/views/content_units/index.html.erb
@@ -38,8 +38,8 @@
 </div>
 <%# 商品登録ボタン（FAB） %>
 <div class="fixed bottom-28 left-0 right-0 mx-auto max-w-xl px-6 flex justify-end z-25">
-  <%= link_to "#", class: "card bg-primary text-white px-6 py-4 rounded-full flex items-center font-bold", data: { controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" } do %>
-    <span class="text-lg">カテゴリ追加</span>
+  <%= link_to new_content_unit_path, class: "card bg-primary text-white px-6 py-4 rounded-full flex items-center font-bold", data: { controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" } do %>
+    <span class="text-lg">内容量単位追加</span>
     <span class="material-symbols-outlined">add</span>
   <% end %>
 </div>

--- a/app/views/content_units/new.html.erb
+++ b/app/views/content_units/new.html.erb
@@ -1,17 +1,17 @@
-<!-- 店舗新規登録 -->
+<!-- 内容量単位新規登録 -->
 <% content_for :arrow_back do %>
   arrow_back
 <% end %>
 <% content_for :title do %>
-  店舗登録
+  内容量単位登録
 <% end %>
 
-<%= form_with model: @store do o|f| %>
+<%= form_with model: @content_unit do |f| %>
   <%= render 'shared/error_messages', object: f.object %>
   <div class ="mb-10">
     <%= f.label :name, class: "block text-black font-bold mb-2"%>
     <div class="flex border border-light-gray rounded-xl px-3 py-3 bg-white focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition">
-      <%= f.text_field :name, placeholder: "例：〇〇スーパー〇〇店 / 〇〇薬局", autocomplete: "off", class: "flex-auto outline-none text-black bg-transparent placeholder-gray" %>
+      <%= f.text_field :name, placeholder: "例：g / ml / 個", autocomplete: "off", class: "flex-auto outline-none text-black bg-transparent placeholder-gray" %>
     </div>
   </div>
   <%= f.submit "この内容で登録する", class: "card w-full bg-primary tracking-widest text-white px-6 py-4 rounded-full flex items-center justify-center font-bold no-underline", data: { controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" } %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -6,6 +6,8 @@ ja:
       category: カテゴリー
       item: 商品
       purchase: 購入履歴
+      content_unit: 単位（単位名）
+      pack_unit: 単位（包装）
     attributes:
       user:
         name: ニックネーム
@@ -21,12 +23,14 @@ ja:
       purchase:
         brand: ブランド名
         content_quantity: 内容量
-        content_unit: 単位（内容量）
         pack_quantity: パック数
-        pack_unit: 単位（パック数）
         price: 価格
         tax_rate: 消費税
         purchased_on: 購入日
+      content_unit:
+        name: 単位名（内容量）
+      pack_unit:
+        name: 単位名（包装）
   footer:
     index: 一覧
     comparison: 比較


### PR DESCRIPTION
### 関連ISSUE
---
close #212 

### 変更内容
---
- 内容量単位の新規登録機能（new / create）を実装しました。
- ContentUnitController に new / create アクションを追加しました。
- 内容量単位登録ページのビューを作成しました。
- 内容量単位一覧ページから登録ページへ遷移するリンクを追加しました。
- 登録成功時のリダイレクトとフラッシュメッセージを設定しました。
- 登録失敗時のエラーメッセージ表示を実装しました。

### 動作確認
---
- 内容量単位一覧ページから登録ページへ遷移できること
- 内容量単位名を入力して正常に登録できること
- 登録後、内容量単位一覧ページにリダイレクトされること
- 未入力や不正な値の場合、エラーメッセージが表示されること
### 補足・レビュアーへのメモ
---