### PR TITLE
内容量単位の削除機能を実装

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -34,7 +34,7 @@ class CategoriesController < ApplicationController
   def destroy
     @category = current_user.categories.find(params[:id])
     @category.destroy
-    redirect_to categories_path, success: "カテゴリを削除しました"
+    redirect_to categories_path, success: "カテゴリを削除しました", status: :see_other
   end
 
   private

--- a/app/controllers/content_units_controller.rb
+++ b/app/controllers/content_units_controller.rb
@@ -31,6 +31,15 @@ class ContentUnitsController < ApplicationController
     end
   end
 
+  def destroy
+    @content_unit = current_user.content_units.find(params[:id])
+    if @content_unit.destroy
+      redirect_to content_units_path, success: "内容量単位を削除しました", status: :see_other
+    else
+      redirect_to content_units_path, alert: "購入履歴があるため削除することができません", status: :see_other
+    end
+  end
+
   private
 
   def content_unit_params

--- a/app/controllers/stores_controller.rb
+++ b/app/controllers/stores_controller.rb
@@ -34,7 +34,7 @@ class StoresController < ApplicationController
   def destroy
     @store = current_user.stores.find(params[:id])
     @store.destroy
-    redirect_to stores_path, success: "店舗を削除しました"
+    redirect_to stores_path, success: "店舗を削除しました", status: :see_other
   end
 
   private

--- a/app/views/content_units/index.html.erb
+++ b/app/views/content_units/index.html.erb
@@ -27,7 +27,7 @@
               class: "flex items-center justify-center w-11
                       bg-blue-400 text-white text-xs font-medium self-stretch" %>
 
-        <%= link_to "削除", "#",
+        <%= link_to "削除", content_unit_path(content_unit),
               data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" },
               class: "flex items-center justify-center w-11
                       bg-red-400 text-white text-xs font-medium


### PR DESCRIPTION
### 関連ISSUE
---
close #214
子ISSUEが全て終了したので親ISSUEを閉じる
close #210

### 変更内容
---
- 内容量単位の削除機能（destroy）を実装しました。
- 内容量単位一覧ページの各内容量単位に削除ボタンを追加しました。
- ログイン中ユーザーが作成した内容量単位のみ削除できるように制御を追加しました。
- 削除前に確認ダイアログを表示するように実装しました。
- 削除成功時のリダイレクトとフラッシュメッセージを設定しました。
- 削除失敗時も同様、リダイレクトとフラッシュメッセージを設定しました。

### 動作確認
---
- 内容量単位一覧ページから削除操作ができること
- 削除前に確認ダイアログが表示されること
- 内容量単位を正常に削除できること
- 削除後、内容量単位一覧ページにリダイレクトされること
- 削除結果に応じたフラッシュメッセージが表示されること
- 他ユーザーの内容量単位が削除できないこと
- 関連データがある場合に削除失敗し、適切にハンドリングされること

### 補足・レビュアーへのメモ
---
他モデルの削除処理において、Turbo環境でのリダイレクト挙動を考慮し、status: :see_other を付与しました