### PR TITLE
商品登録時の入力補助（履歴ベースのオートサジェスト）の実装 

### DIFF
--- a/app/controllers/item_registrations_controller.rb
+++ b/app/controllers/item_registrations_controller.rb
@@ -1,6 +1,8 @@
 class ItemRegistrationsController < ApplicationController
   def new
     @form = ItemRegistrationForm.new
+    @items = current_user.items.order(:name)
+    @content_units = current_user.content_units.order(:name)
   end
 
   def create
@@ -9,6 +11,8 @@ class ItemRegistrationsController < ApplicationController
     if @form.save
       redirect_to complete_item_registration_path(item_id: @form.item.id, purchase_id: @form.purchase.id)
     else
+      @items = current_user.items.order(:name)
+      @content_units = current_user.content_units.order(:name)
       flash.now[:error] = "商品の登録に失敗しました"
       render :new, status: :unprocessable_entity
     end

--- a/app/controllers/item_registrations_controller.rb
+++ b/app/controllers/item_registrations_controller.rb
@@ -28,7 +28,7 @@ class ItemRegistrationsController < ApplicationController
   def last_purchase
     item = current_user.items.find_by(name: params[:name])
     last_purchase = item&.purchases&.order(purchased_on: :desc)&.first
-    render json: { 
+    render json: {
       content_quantity: last_purchase&.content_quantity,
       content_unit_name: last_purchase&.content_unit&.name
     }

--- a/app/controllers/item_registrations_controller.rb
+++ b/app/controllers/item_registrations_controller.rb
@@ -18,11 +18,21 @@ class ItemRegistrationsController < ApplicationController
     end
   end
 
+  # 商品登録完了確認用の遷移アクション
   def complete
     @item = current_user.items.find_by(id: params[:item_id])
     @purchase = @item.purchases.find_by(id: params[:purchase_id])
   end
 
+  # 前回内容量・単位の自動補完用アクション
+  def last_purchase
+    item = current_user.items.find_by(name: params[:name])
+    last_purchase = item&.purchases&.order(purchased_on: :desc)&.first
+    render json: { 
+      content_quantity: last_purchase&.content_quantity,
+      content_unit_name: last_purchase&.content_unit&.name
+    }
+  end
 
   private
 

--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -9,7 +9,7 @@ class PurchasesController < ApplicationController
     @purchase = current_user.purchases.includes(:item, :store, :content_unit, :pack_unit, item: :category).find(params[:id])
     @categories = current_user.categories.order(:name)
     @items = current_user.items.order(:name)
-    @brands = current_user.purchases.where.not(brand: [nil, ""]).distinct.pluck(:brand).sort
+    @brands = current_user.purchases.where.not(brand: [ nil, "" ]).distinct.pluck(:brand).sort
     @content_units = current_user.content_units.order(:name)
     @pack_units = current_user.pack_units.order(:name)
     @stores = current_user.stores.order(:name)
@@ -38,7 +38,7 @@ class PurchasesController < ApplicationController
     else
       @categories = current_user.categories.order(:name)
       @items = current_user.items.order(:name)
-      @brands = current_user.purchases.where.not(brand: [nil, ""]).distinct.pluck(:brand).sort
+      @brands = current_user.purchases.where.not(brand: [ nil, "" ]).distinct.pluck(:brand).sort
       @content_units = current_user.content_units.order(:name)
       @pack_units = current_user.pack_units.order(:name)
       @stores = current_user.stores.order(:name)

--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -7,6 +7,12 @@ class PurchasesController < ApplicationController
 
   def edit
     @purchase = current_user.purchases.includes(:item, :store, :content_unit, :pack_unit, item: :category).find(params[:id])
+    @categories = current_user.categories.order(:name)
+    @items = current_user.items.order(:name)
+    @brands = current_user.purchases.where.not(brand: [nil, ""]).distinct.pluck(:brand).sort
+    @content_units = current_user.content_units.order(:name)
+    @pack_units = current_user.pack_units.order(:name)
+    @stores = current_user.stores.order(:name)
     @form = PurchaseUpdateForm.new(
       category_name:      @purchase.item.category&.name,
       item_name:          @purchase.item.name,
@@ -28,10 +34,14 @@ class PurchasesController < ApplicationController
     @form.user = current_user
     @form.purchase = @purchase
     if @form.update
-      puts "成功"
       redirect_to item_purchases_path(@purchase.item), success: "商品情報の詳細編集に成功しました"
     else
-      puts "失敗"
+      @categories = current_user.categories.order(:name)
+      @items = current_user.items.order(:name)
+      @brands = current_user.purchases.where.not(brand: [nil, ""]).distinct.pluck(:brand).sort
+      @content_units = current_user.content_units.order(:name)
+      @pack_units = current_user.pack_units.order(:name)
+      @stores = current_user.stores.order(:name)
       flash.now[:error] = "商品情報の編集に失敗しました"
       render :edit, status: :unprocessable_entity
     end
@@ -40,7 +50,7 @@ class PurchasesController < ApplicationController
   def destroy
     purchase = current_user.purchases.find(params[:id])
     purchase.destroy
-    redirect_to purchases_path, success: "購入履歴を削除しました"
+    redirect_to item_purchases_path(purchase.item), success: "購入履歴を削除しました"
   end
 
   private

--- a/app/javascript/controllers/compare_controller.js
+++ b/app/javascript/controllers/compare_controller.js
@@ -4,7 +4,7 @@ import { Controller } from "@hotwired/stimulus"
 // static targets = […]でJSで操作したいHTMLの要素を定義
 export default class extends Controller {
 
-// 画面読み込み時、JS実行（購入履歴からのデータ取得時をフォームに自動出力した際にJSが走らないため） 
+  // 画面読み込み時、JS実行（購入履歴からのデータ取得時をフォームに自動出力した際にJSが走らないため） 
   connect() {
     this.calculate()
   }

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -15,3 +15,7 @@ application.register("hello", HelloController)
 
 import SwipeController from "./swipe_controller"
 application.register("swipe", SwipeController)
+
+import RestoreValuesController from "./restore_values_controller"
+application.register("restore-values", RestoreValuesController)
+

--- a/app/javascript/controllers/restore_values_controller.js
+++ b/app/javascript/controllers/restore_values_controller.js
@@ -1,0 +1,46 @@
+// Stimulusの読み込み
+import { Controller } from "@hotwired/stimulus"
+
+// static targets = […]でJSで操作したいHTMLの要素を定義
+export default class extends Controller {
+
+  // HTML側で参照したい要素を定義（商品名・内容量・単価）
+  static targets = ["itemName", "contentQuantity", "contentUnit", "message"
+  ]
+
+  async restoreValues() {
+    const name = this.itemNameTarget.value
+    if (!name) return
+
+    const response = await fetch(`/item_registration/last_purchase?name=${encodeURIComponent(name)}`)
+    const data = await response.json()
+
+    let restored = false
+
+    if (data.content_quantity) {
+      this.contentQuantityTarget.value = data.content_quantity
+      this.highlight(this.contentQuantityTarget)
+      restored = true
+    }
+    if (data.content_unit_name) {
+      this.contentUnitTarget.value = data.content_unit_name
+      this.highlight(this.contentUnitTarget)
+      restored = true
+    }
+
+    if (restored) {
+      this.showMessage()
+    }
+  }
+
+  highlight(element) {
+    element.classList.add("bg-amber-50", "border-amber-400", "text-amber-900")
+  }
+
+  showMessage() {
+    this.messageTarget.classList.remove("hidden")
+    setTimeout(() => {
+      this.messageTarget.classList.add("hidden")
+    }, 5000)
+  }
+}

--- a/app/javascript/controllers/restore_values_controller.js
+++ b/app/javascript/controllers/restore_values_controller.js
@@ -8,6 +8,8 @@ export default class extends Controller {
   static targets = ["itemName", "contentQuantity", "contentUnit", "message"
   ]
 
+  static values = { url: String }
+
   async restoreValues() {
     const name = this.itemNameTarget.value
     if (!name) return

--- a/app/views/item_registrations/new.html.erb
+++ b/app/views/item_registrations/new.html.erb
@@ -12,88 +12,99 @@
   商品登録
 <% end %>
 
-<!-- 入力項目（商品名・内容量・単位・価格・消費税率） -->
-<%= form_with model: @form, url: item_registration_path, method: :post, scope: :item_registrations do |f| %>
-  <%= render 'shared/error_messages', object: f.object %>
-  <div class="space-y-6">
+<!-- stimulusのコントローラー定義 -->
+<div data-controller="restore-values" data-restore-values-url-value="<%= last_purchase_item_registration_path %>">
 
-    <!-- 商品情報カード -->
-    <h1 class="text-xl font-bold border-b  text-primary border-primary pb-2">商品情報</h1>
-    <div class="bg-white rounded-2xl border border-light-gray p-4 space-y-4">
+  <!-- 入力項目（商品名・内容量・単位・価格・消費税率） -->
+  <%= form_with model: @form, url: item_registration_path, method: :post, scope: :item_registrations do |f| %>
+    <%= render 'shared/error_messages', object: f.object %>
+    <div class="space-y-6">
 
-      <!-- 商品名 -->
-      <%= f.label :item_name, class: "block text-black font-bold mb-2"%>
-      <div class="form flex">
-        <%= f.text_field :item_name, placeholder: "例：牛乳 / 箱ティッシュ", autocomplete: "off", list: "items_list", class: "flex-auto outline-none text-black bg-transparent placeholder-gray" %>
-        <datalist id="items_list">
-          <% @items.each do |item| %>
-            <option value="<%= item.name %>">
-          <% end %>
-        </datalist>
-      </div>
+      <!-- 商品情報カード -->
+      <h1 class="text-xl font-bold border-b  text-primary border-primary pb-2">商品情報</h1>
+      <div class="bg-white rounded-2xl border border-light-gray p-4 space-y-4">
 
-      <!-- 2列 -->
-      <div class="grid grid-cols-2 gap-2">
-
-        <!-- 内容量 -->
-        <div>
-          <%= f.label :content_quantity, class: "block text-black font-bold mb-2"%>
-          <div class="form">
-            <%= f.number_field :content_quantity, placeholder: "例：3 , 500", autocomplete: "off", inputmode: "decimal", step: 0.01, class: "w-full flex-auto outline-none text-black bg-transparent placeholder-gray" %>
-          </div>
+        <!-- 商品名 -->
+        <%= f.label :item_name, class: "block text-black font-bold mb-2"%>
+        <div class="form flex">
+          <%= f.text_field :item_name, placeholder: "例：牛乳 / 箱ティッシュ", autocomplete: "off", list: "items_list", class: "flex-auto outline-none text-black bg-transparent placeholder-gray", data: { restore_values_target: "itemName", action: "change->restore-values#restoreValues" } %>
+          <datalist id="items_list">
+            <% @items.each do |item| %>
+              <option value="<%= item.name %>">
+            <% end %>
+          </datalist>
         </div>
 
-        <!-- 単位（内容量） -->
-        <div>
-          <%= f.label :content_unit_name, class: "block text-black font-bold mb-2"%>
-          <div class="form">
-            <%= f.text_field :content_unit_name, placeholder: "例：ml、g", autocomplete: "off", list: "content_units_list", class: "w-full flex-auto outline-none text-black bg-transparent placeholder-gray" %>
-            <datalist id="content_units_list">
-              <% @content_units.each do |unit| %>
-                <option value="<%= unit.name %>">
-              <% end %>
-            </datalist>
+        <!-- 前回の値が反映された際の通知メッセージ -->
+        <div data-restore-values-target="message" 
+            class="hidden mt-2 py-2 px-3 bg-accent/20 border-l-4 border-accent rounded font-bold text-accent flex items-center gap-2">
+          <span>✓</span>
+          <span>前回の登録内容を反映しました</span>
+        </div>
+
+        <!-- 2列 -->
+        <div class="grid grid-cols-2 gap-2">
+
+          <!-- 内容量 -->
+          <div>
+            <%= f.label :content_quantity, class: "block text-black font-bold mb-2"%>
+            <div class="form">
+              <%= f.number_field :content_quantity, placeholder: "例：3 , 500", autocomplete: "off", inputmode: "decimal", step: 0.01, class: "w-full flex-auto outline-none text-black bg-transparent placeholder-gray", data: { restore_values_target: "contentQuantity" } %>
+            </div>
+          </div>
+
+          <!-- 単位（内容量） -->
+          <div>
+            <%= f.label :content_unit_name, class: "block text-black font-bold mb-2"%>
+            <div class="form">
+              <%= f.text_field :content_unit_name, placeholder: "例：ml、g", autocomplete: "off", list: "content_units_list", class: "w-full flex-auto outline-none text-black bg-transparent placeholder-gray", data: { restore_values_target: "contentUnit" } %>
+              <datalist id="content_units_list">
+                <% @content_units.each do |unit| %>
+                  <option value="<%= unit.name %>">
+                <% end %>
+              </datalist>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- 価格情報カード -->
+      <h1 class="text-xl font-bold border-b text-primary border-primary pb-2">価格情報</h1>
+      <div class="bg-white rounded-2xl border border-light-gray p-4 mb-10 space-y-4">
+
+        <!-- ユーザーが入力する価格 -->
+        <%= f.label :price, class: "block text-black font-bold mb-2"%>
+        <div class="form flex">
+          <%= f.number_field :price, placeholder: "例：298 / 1200", autocomplete: "off", inputmode: "numeric", class: "flex-auto outline-none text-black bg-transparent placeholder-gray" %>
+        </div>
+
+        <!-- 消費税率 -->
+        <%= f.label :tax_rate, class: "block text-black font-bold mb-2"%>
+        <div class="flex bg-light-gray dark:bg-black p-1 rounded-xl">
+          <!-- 税抜 (値: 0) -->
+          <div class="flex-1">
+            <%= f.radio_button :tax_rate, 0, class: "hidden peer", id: "tax-none" %>
+            <%= f.label :tax_rate, "税抜", value: 0, for: "tax-none", class: "block text-center py-2 text-sm font-medium text-dark-gray rounded-lg cursor-pointer transition-all peer-checked:bg-white peer-checked:text-primary peer-checked:shadow-sm" %>
+          </div>
+
+          <!-- 8% (値: 8) -->
+          <div class="flex-1">
+            <%= f.radio_button :tax_rate, 8, class: "hidden peer", id: "tax-8" %>
+            <%= f.label :tax_rate, "8%", value: 8, for: "tax-8", class: "block text-center py-2 text-sm font-medium text-dark-gray rounded-lg cursor-pointer transition-all peer-checked:bg-white peer-checked:text-primary peer-checked:shadow-sm" %>
+          </div>
+
+          <!-- 10% (値: 10) -->
+          <div class="flex-1">
+            <%= f.radio_button :tax_rate, 10, class: "hidden peer", id: "tax-10" %>
+            <%= f.label :tax_rate, "10%", value: 10, for: "tax-10", class: "block text-center py-2 text-sm font-medium text-dark-gray rounded-lg cursor-pointer transition-all peer-checked:bg-white peer-checked:text-primary peer-checked:shadow-sm" %>
           </div>
         </div>
       </div>
     </div>
 
-    <!-- 価格情報カード -->
-    <h1 class="text-xl font-bold border-b text-primary border-primary pb-2">価格情報</h1>
-    <div class="bg-white rounded-2xl border border-light-gray p-4 mb-10 space-y-4">
-
-      <!-- ユーザーが入力する価格 -->
-      <%= f.label :price, class: "block text-black font-bold mb-2"%>
-      <div class="form flex">
-        <%= f.number_field :price, placeholder: "例：298 / 1200", autocomplete: "off", inputmode: "numeric", class: "flex-auto outline-none text-black bg-transparent placeholder-gray" %>
-      </div>
-
-      <!-- 消費税率 -->
-      <%= f.label :tax_rate, class: "block text-black font-bold mb-2"%>
-      <div class="flex bg-light-gray dark:bg-black p-1 rounded-xl">
-        <!-- 税抜 (値: 0) -->
-        <div class="flex-1">
-          <%= f.radio_button :tax_rate, 0, class: "hidden peer", id: "tax-none" %>
-          <%= f.label :tax_rate, "税抜", value: 0, for: "tax-none", class: "block text-center py-2 text-sm font-medium text-dark-gray rounded-lg cursor-pointer transition-all peer-checked:bg-white peer-checked:text-primary peer-checked:shadow-sm" %>
-        </div>
-
-        <!-- 8% (値: 8) -->
-        <div class="flex-1">
-          <%= f.radio_button :tax_rate, 8, class: "hidden peer", id: "tax-8" %>
-          <%= f.label :tax_rate, "8%", value: 8, for: "tax-8", class: "block text-center py-2 text-sm font-medium text-dark-gray rounded-lg cursor-pointer transition-all peer-checked:bg-white peer-checked:text-primary peer-checked:shadow-sm" %>
-        </div>
-
-        <!-- 10% (値: 10) -->
-        <div class="flex-1">
-          <%= f.radio_button :tax_rate, 10, class: "hidden peer", id: "tax-10" %>
-          <%= f.label :tax_rate, "10%", value: 10, for: "tax-10", class: "block text-center py-2 text-sm font-medium text-dark-gray rounded-lg cursor-pointer transition-all peer-checked:bg-white peer-checked:text-primary peer-checked:shadow-sm" %>
-        </div>
-      </div>
+    <!-- 登録ボタン -->
+    <div class="mx-auto px-6">
+      <%= f.submit "内容を確認して登録する", class: "card w-full bg-primary tracking-widest text-white px-6 py-4 rounded-full flex items-center justify-center font-bold no-underline", data: { controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" } %>
     </div>
-  </div>
-
-  <!-- 登録ボタン -->
-  <div class="mx-auto px-6">
-    <%= f.submit "内容を確認して登録する", class: "card w-full bg-primary tracking-widest text-white px-6 py-4 rounded-full flex items-center justify-center font-bold no-underline", data: { controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" } %>
-  </div>
-<% end %>
+  <% end %>
+</div>

--- a/app/views/item_registrations/new.html.erb
+++ b/app/views/item_registrations/new.html.erb
@@ -24,7 +24,12 @@
       <!-- 商品名 -->
       <%= f.label :item_name, class: "block text-black font-bold mb-2"%>
       <div class="form flex">
-        <%= f.text_field :item_name, placeholder: "例：牛乳 / 箱ティッシュ", autocomplete: "off", class: "flex-auto outline-none text-black bg-transparent placeholder-gray" %>
+        <%= f.text_field :item_name, placeholder: "例：牛乳 / 箱ティッシュ", autocomplete: "off", list: "items_list", class: "flex-auto outline-none text-black bg-transparent placeholder-gray" %>
+        <datalist id="items_list">
+          <% @items.each do |item| %>
+            <option value="<%= item.name %>">
+          <% end %>
+        </datalist>
       </div>
 
       <!-- 2列 -->
@@ -34,7 +39,7 @@
         <div>
           <%= f.label :content_quantity, class: "block text-black font-bold mb-2"%>
           <div class="form">
-            <%= f.number_field :content_quantity, placeholder: "例：3 , 500", autocomplete: "off", inputmode: "decimal", step: 0.01 class: "w-full flex-auto outline-none text-black bg-transparent placeholder-gray" %>
+            <%= f.number_field :content_quantity, placeholder: "例：3 , 500", autocomplete: "off", inputmode: "decimal", step: 0.01, class: "w-full flex-auto outline-none text-black bg-transparent placeholder-gray" %>
           </div>
         </div>
 
@@ -42,7 +47,12 @@
         <div>
           <%= f.label :content_unit_name, class: "block text-black font-bold mb-2"%>
           <div class="form">
-            <%= f.text_field :content_unit_name, placeholder: "例：ml、g", autocomplete: "off", class: "w-full flex-auto outline-none text-black bg-transparent placeholder-gray" %>
+            <%= f.text_field :content_unit_name, placeholder: "例：ml、g", autocomplete: "off", list: "content_units_list", class: "w-full flex-auto outline-none text-black bg-transparent placeholder-gray" %>
+            <datalist id="content_units_list">
+              <% @content_units.each do |unit| %>
+                <option value="<%= unit.name %>">
+              <% end %>
+            </datalist>
           </div>
         </div>
       </div>

--- a/app/views/purchases/edit.html.erb
+++ b/app/views/purchases/edit.html.erb
@@ -24,25 +24,45 @@
       <!-- カテゴリ名 -->
       <%= f.label :category_name, class: "block text-black font-bold mb-2"%>
       <div class="form flex">
-        <%= f.text_field :category_name, placeholder: "例：飲料 / 日用品", autocomplete: "off", class: "flex-auto outline-none text-black bg-transparent placeholder-gray" %>
+        <%= f.text_field :category_name, placeholder: "例：飲料 / 日用品", autocomplete: "off", list: "categories_list", class: "flex-auto outline-none text-black bg-transparent placeholder-gray" %>
+        <datalist id="categories_list">
+          <% @categories.each do |category| %>
+            <option value="<%= category.name %>">
+          <% end %>
+        </datalist>
       </div>
 
       <!-- 商品名 -->
       <%= f.label :item_name, class: "block text-black font-bold mb-2"%>
       <div class="form flex">
-        <%= f.text_field :item_name, placeholder: "例：牛乳 / 箱ティッシュ", autocomplete: "off", class: "flex-auto outline-none text-black bg-transparent placeholder-gray" %>
+        <%= f.text_field :item_name, placeholder: "例：牛乳 / 箱ティッシュ", autocomplete: "off", list: "items_list", class: "flex-auto outline-none text-black bg-transparent placeholder-gray" %>
+        <datalist id="items_list">
+          <% @items.each do |item| %>
+            <option value="<%= item.name %>">
+          <% end %>
+        </datalist>
       </div>
 
       <!-- 店舗名 -->
       <%= f.label :store_name, class: "block text-black font-bold mb-2"%>
       <div class="form flex">
-        <%= f.text_field :store_name, placeholder: "例：〇〇スーパー〇〇店", autocomplete: "off", class: "flex-auto outline-none text-black bg-transparent placeholder-gray" %>
+        <%= f.text_field :store_name, placeholder: "例：〇〇スーパー〇〇店", autocomplete: "off", list: "stores_list", class: "flex-auto outline-none text-black bg-transparent placeholder-gray" %>
+        <datalist id="stores_list">
+          <% @stores.each do |store| %>
+            <option value="<%= store.name %>">
+          <% end %>
+        </datalist>
       </div>
 
       <!-- ブランド名 -->
       <%= f.label :brand, class: "block text-black font-bold mb-2"%>
       <div class="form flex">
-        <%= f.text_field :brand, placeholder: "例：伊藤園 / 花王", autocomplete: "off", class: "flex-auto outline-none text-black bg-transparent placeholder-gray" %>
+        <%= f.text_field :brand, placeholder: "例：伊藤園 / 花王", autocomplete: "off", list: "brands_list", class: "flex-auto outline-none text-black bg-transparent placeholder-gray" %>
+        <datalist id="brands_list">
+          <% @brands.each do |brand| %>
+            <option value="<%= brand %>">
+          <% end %>
+        </datalist>
       </div>
 
       <!-- 2列 -->
@@ -60,7 +80,12 @@
         <div>
           <%= f.label :content_unit_name, class: "block text-black font-bold mb-2"%>
           <div class="form">
-            <%= f.text_field :content_unit_name, placeholder: "例：ml / g", autocomplete: "off", class: "w-full flex-auto outline-none text-black bg-transparent placeholder-gray" %>
+            <%= f.text_field :content_unit_name, placeholder: "例：ml / g", autocomplete: "off", list: "content_units_list", class: "w-full flex-auto outline-none text-black bg-transparent placeholder-gray" %>
+            <datalist id="content_units_list">
+              <% @content_units.each do |unit| %>
+                <option value="<%= unit.name %>">
+              <% end %>
+            </datalist>
           </div>
         </div>
 
@@ -72,11 +97,16 @@
           </div>
         </div>
 
-        <!-- 単位（内容量） -->
+        <!-- 単位（包装数） -->
         <div>
           <%= f.label :pack_unit_name, class: "block text-black font-bold mb-2"%>
           <div class="form">
-            <%= f.text_field :pack_unit_name, placeholder: "例：セット / 箱", autocomplete: "off", class: "w-full flex-auto outline-none text-black bg-transparent placeholder-gray" %>
+            <%= f.text_field :pack_unit_name, placeholder: "例：セット / 箱", autocomplete: "off", list: "pack_units_list", class: "w-full flex-auto outline-none text-black bg-transparent placeholder-gray" %>
+            <datalist id="pack_units_list">
+              <% @pack_units.each do |unit| %>
+                <option value="<%= unit.name %>">
+              <% end %>
+            </datalist>
           </div>
         </div>
       </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,9 +10,9 @@ Rails.application.routes.draw do
   # 未ログイン時のトップ画面
   root "home#top"
 
-  # 商品簡易登録用（登録用new・createと完了ダイアログcomplete）
+  # 商品簡易登録用（登録用new・create・完了ダイアログcomplete・自動補助入力last_purchase）
   resource :item_registration, only: [ :new, :create ] do
-    get :complete
+    get :complete, :last_purchase
   end
 
   # カテゴリ一覧・登録・編集・削除


### PR DESCRIPTION
### 関連ISSUE
---
close #215 

### 変更内容
---
- 新規商品登録
  - 商品名・内容量単位のオートコンプリート実装しました。
  - 履歴商品orない場合は手入力で新規登録できるよう実装しました。
  - 商品名入力後、前回履歴の内容量と内容量単位を自動反映させるstimulus実装しました。
  - 自動反映時、メッセージを表示しました
- 購入履歴編集
  - カテゴリ名・商品名・店舗名・ブランド名・内容量単位・パック数単位のオートコンプリート実装しました。

### 動作確認
---
- 新規登録時、商品名・内容量単位の過去履歴がトグル形式で選択可能
- 履歴に入力したことがない商品名の場合、そのままフォームに入力することができる
- トグル形式で選択した場合、前回入力したその商品の内容量と単位が自動的に入力される
- 購入履歴編集時、カテゴリ名・商品名・店舗名・ブランド名・内容量単位・パック数単位がトグル形式で選択可能

### 補足・レビュアーへのメモ
---