### PR TITLE
【検索・フィルター・並び替え機能】④購入履歴一覧画面に店舗名フィルタ機能を実装する

### DIFF
--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -2,8 +2,8 @@ class PurchasesController < ApplicationController
   def index
     @item = current_user.items.find(params[:item_id])
     @q = @item.purchases.ransack(params[:q])
-    @purchases = @q.result(distinct: true).includes(:store, :content_unit, :pack_unit )
-    @stores = @item.purchases.map(&:store).compact.uniq
+    @purchases = @q.result(distinct: true).includes(:store, :content_unit, :pack_unit)
+    @stores = @item.purchases.includes(:store).map(&:store).compact.uniq
     @lowest_purchase = @item.purchases.order(:unit_price).first
   end
 

--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -1,7 +1,9 @@
 class PurchasesController < ApplicationController
   def index
     @item = current_user.items.find(params[:item_id])
-    @purchases = @item.purchases.includes(:store, :content_unit, :pack_unit).order(purchased_on: :desc)
+    @q = @item.purchases.ransack(params[:q])
+    @purchases = @q.result(distinct: true).includes(:store, :content_unit, :pack_unit )
+    @stores = @item.purchases.map(&:store).compact.uniq
     @lowest_purchase = @item.purchases.order(:unit_price).first
   end
 

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -19,12 +19,12 @@ class Purchase < ApplicationRecord
   belongs_to :content_unit
   belongs_to :pack_unit, optional: true # pack_unit_idがnull許可に変更
 
-  # --- ransack設定 Itemモデルのnameカラムのみ検索許可 ---
+  # --- ransack設定 Purchaseモデルでは直接の属性検索は許可しない ---
   def self.ransackable_attributes(auth_object = nil)
-    %w[store]
+    %w[]
   end
   
-  # --- ransack設定 Purchaseモデルの関連テーブルの使用許可 ---
+  # --- ransack設定 store関連経由での検索を許可（購入履歴の店舗名絞り込み用） ---
   def self.ransackable_associations(auth_object = nil)
     %w[store]
   end

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -19,6 +19,17 @@ class Purchase < ApplicationRecord
   belongs_to :content_unit
   belongs_to :pack_unit, optional: true # pack_unit_idがnull許可に変更
 
+  # --- ransack設定 Itemモデルのnameカラムのみ検索許可 ---
+  def self.ransackable_attributes(auth_object = nil)
+    %w[store]
+  end
+  
+  # --- ransack設定 Purchaseモデルの関連テーブルの使用許可 ---
+  def self.ransackable_associations(auth_object = nil)
+    %w[store]
+  end
+
+
   private
 
   # --- 前後の空白削除と空ならnilにする処理 ---

--- a/app/models/store.rb
+++ b/app/models/store.rb
@@ -13,6 +13,11 @@ class Store < ApplicationRecord
 
   private
 
+  # --- ransack設定 Itemモデルのnameカラムのみ検索許可 ---
+  def self.ransackable_attributes(auth_object = nil)
+    %w[name]
+  end
+
   # --- 前後の空白削除と空ならnilにする処理 ---
   def normalize_name
     self.name = name&.gsub(/\A[[:space:]]+|[[:space:]]+\z/, "")   # 全角半角空白削除

--- a/app/models/store.rb
+++ b/app/models/store.rb
@@ -11,13 +11,14 @@ class Store < ApplicationRecord
   belongs_to :user
   has_many :purchases, dependent: :nullify # store削除時にpurchases.store_idをnil
 
-  private
-
+  
   # --- ransack設定 Itemモデルのnameカラムのみ検索許可 ---
   def self.ransackable_attributes(auth_object = nil)
     %w[name]
   end
-
+  
+  private
+  
   # --- 前後の空白削除と空ならnilにする処理 ---
   def normalize_name
     self.name = name&.gsub(/\A[[:space:]]+|[[:space:]]+\z/, "")   # 全角半角空白削除

--- a/app/views/purchases/index.html.erb
+++ b/app/views/purchases/index.html.erb
@@ -20,7 +20,7 @@
 
 <!-- 最安値単価表示 -->
 <% if @lowest_purchase %>
-  <div class="bg-white border-2 border-accent rounded-2xl overflow-hidden mb-2">
+  <div class="bg-white border-2 border-accent rounded-2xl overflow-hidden mb-4">
     <div class="h-1 w-full bg-accent"></div>
     <div class="p-4">
       
@@ -74,6 +74,19 @@
     </div>
   </div>
 <% end %>
+<div class="mb-4">
+  <%= search_form_for @q, url: item_purchases_path(@item) do |f| %>
+    <div class="form flex">
+      <span class="material-symbols-outlined text-middle-gray">search</span>
+      <%= f.search_field :store_name_cont, placeholder: "店舗名で購入履歴を絞り込むことができます", list: "stores_list", class: "flex-auto outline-none pl-2 text-black bg-transparent placeholder-gray" %>
+      <datalist id="stores_list">
+        <% @stores.each do |store| %>
+          <option value="<%= store.name %>">
+        <% end %>
+      </datalist>
+    </div>
+  <% end %>
+</div>
 
 <!-- 購入履歴一覧 -->
 <p class="text-xs font-medium text-middle-gray tracking-widest uppercase mt-5 mb-2">購入履歴（新しい順）</p>


### PR DESCRIPTION
### 関連ISSUE
---
close #166

### 変更内容
---
- 購入履歴欄で店舗名の名前検索で表示を絞り込む機能を実装しました。

### 動作確認
---
- 購入履歴一覧画面にて、名前検索で表示を絞り込み
- 

### 補足・レビュアーへのメモ
---