### PR TITLE
Feature/purchases sort

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/myapp_test # PostgreSQLへの接続先を環境変数で指定
           MAIL_FROM: "from@example.com" # SMTPのテスト用メールフォームを指定
           # REDIS_URL: redis://localhost:6379/0
-        # run: bundle exec rspec spec/models spec/requests  spec/system # runはシェルコマンドを実行できる テーブル設計変更に伴い一時的にスキップ
+        run: bundle exec rspec spec/models spec/requests  spec/system # runはシェルコマンドを実行できる
 
       - name: Keep screenshots from failed system tests # ステップの名前
         uses: actions/upload-artifact@v4                # usesで既存アクションを呼び出せる

--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -2,7 +2,7 @@ class PurchasesController < ApplicationController
   def index
     @item = current_user.items.find(params[:item_id])
     @q = @item.purchases.ransack(params[:q])
-    @q.sorts = ["purchased_on desc"] if @q.sorts.empty?
+    @q.sorts = [ "purchased_on desc" ] if @q.sorts.empty?
     @purchases = @q.result(distinct: true).includes(:store, :content_unit, :pack_unit)
     @stores = @item.purchases.includes(:store).map(&:store).compact.uniq
     @lowest_purchase = @item.purchases.order(:unit_price).first

--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -2,6 +2,7 @@ class PurchasesController < ApplicationController
   def index
     @item = current_user.items.find(params[:item_id])
     @q = @item.purchases.ransack(params[:q])
+    @q.sorts = ["purchased_on desc"] if @q.sorts.empty?
     @purchases = @q.result(distinct: true).includes(:store, :content_unit, :pack_unit)
     @stores = @item.purchases.includes(:store).map(&:store).compact.uniq
     @lowest_purchase = @item.purchases.order(:unit_price).first

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -23,7 +23,7 @@ class Purchase < ApplicationRecord
   def self.ransackable_attributes(auth_object = nil)
     %w[unit_price purchased_on]
   end
-  
+
   # --- ransack設定 store関連経由での検索を許可（購入履歴の店舗名絞り込み用） ---
   def self.ransackable_associations(auth_object = nil)
     %w[store]

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -21,7 +21,7 @@ class Purchase < ApplicationRecord
 
   # --- ransack設定 Purchaseモデルでは直接の属性検索は許可しない ---
   def self.ransackable_attributes(auth_object = nil)
-    %w[]
+    %w[unit_price purchased_on]
   end
   
   # --- ransack設定 store関連経由での検索を許可（購入履歴の店舗名絞り込み用） ---

--- a/app/models/store.rb
+++ b/app/models/store.rb
@@ -11,14 +11,13 @@ class Store < ApplicationRecord
   belongs_to :user
   has_many :purchases, dependent: :nullify # store削除時にpurchases.store_idをnil
 
-  
   # --- ransack設定 Itemモデルのnameカラムのみ検索許可 ---
   def self.ransackable_attributes(auth_object = nil)
     %w[name]
   end
-  
+
   private
-  
+
   # --- 前後の空白削除と空ならnilにする処理 ---
   def normalize_name
     self.name = name&.gsub(/\A[[:space:]]+|[[:space:]]+\z/, "")   # 全角半角空白削除

--- a/app/views/purchases/index.html.erb
+++ b/app/views/purchases/index.html.erb
@@ -74,11 +74,18 @@
     </div>
   </div>
 <% end %>
+<div class="flex justify-between items-center mb-5">
+  <h2 class="text-xl font-bold text-middle-gray">購入履歴</h2>
+  <div class="flex gap-4 text-xl text-middle-gray">
+    <span class="underline underline-offset-4"><%= sort_link(@q, :unit_price, "単価") %></span>
+    <span class="underline underline-offset-4"><%= sort_link(@q, :purchased_on, "購入日")%></span>
+  </div>
+</div>
 <div class="mb-4">
   <%= search_form_for @q, url: item_purchases_path(@item) do |f| %>
     <div class="form flex">
       <span class="material-symbols-outlined text-middle-gray">search</span>
-      <%= f.search_field :store_name_cont, placeholder: "店舗名で購入履歴を絞り込むことができます", list: "stores_list", class: "flex-auto outline-none pl-2 text-black bg-transparent placeholder-gray" %>
+      <%= f.search_field :store_name_cont, placeholder: "店舗名で絞り込み", list: "stores_list", class: "flex-auto outline-none pl-2 text-black bg-transparent placeholder-gray" %>
       <datalist id="stores_list">
         <% @stores.each do |store| %>
           <option value="<%= store.name %>">
@@ -88,14 +95,12 @@
   <% end %>
 </div>
 
-<!-- 購入履歴一覧 -->
-<p class="text-xs font-medium text-middle-gray tracking-widest uppercase mt-5 mb-2">購入履歴（新しい順）</p>
 <div class="space-y-2">
   <% @purchases.each do |purchase| %>
     <% is_lowest = purchase.id == @lowest_purchase&.id %>
     <div class="swipe-card" data-controller="swipe" data-action="touchstart->swipe#touchstart touchend->swipe#touchend touchstart@document->swipe#outsideClick">
 
-    <!-- 左側の緑ボーダー線の固定 -->
+      <!-- 左側の緑ボーダー線の固定 -->
       <div class="absolute left-0 top-0 bottom-0 w-1.5 z-30 <%= is_lowest ? 'bg-accent' : 'bg-primary' %> rounded-l-2xl"></div>
 
       <!-- テキスト部分の固定 -->

--- a/app/views/stores/new.html.erb
+++ b/app/views/stores/new.html.erb
@@ -6,7 +6,7 @@
   店舗登録
 <% end %>
 
-<%= form_with model: @store do o|f| %>
+<%= form_with model: @store do |f| %>
   <%= render 'shared/error_messages', object: f.object %>
   <div class ="mb-10">
     <%= f.label :name, class: "block text-black font-bold mb-2"%>


### PR DESCRIPTION
### 関連ISSUE
---
close #167
子ISSUEが全て終了したので親ISSUEもcloseする
close #162 
### 変更内容
---
- 購入履歴画面で単価・購入日の並び替え機能を実装しました。

### 動作確認
---
- 購入履歴画面で単価の降順・昇順をクリックで選択できる
- 購入日も同様とする

### 補足・レビュアーへのメモ
---
テーブル設計以降の処理が終了したので、CI、CDを起動します。