### PR TITLE
比較画面に遷移するNameErrorを修正

### DIFF
--- a/app/views/comparison/index.html.erb
+++ b/app/views/comparison/index.html.erb
@@ -18,7 +18,7 @@
       </div>
       <h2 class="text-xl font-bold text-center mb-3">商品A</h2>
 
-      <%= form_with model: @purchase_a, url: new_step1_items_path, method: :get, scope: :purchase_a, class: "space-y-4 text-xs" do |f| %>
+      <%= form_with model: @purchase_a, url: new_item_registration_path, method: :get, scope: :purchase_a, class: "space-y-4 text-xs" do |f| %>
         <div>
           <%= f.label :content_quantity, "内容量" ,class: "text-black" %>
           <div class="mt-1 flex items-center border border-light-gray rounded-lg bg-white focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition">
@@ -83,7 +83,7 @@
         <span class="bg-primary text-white text-xs font-bold px-3 py-1 rounded-full">おトク！</span>
       </div>
       <h2 class="text-xl font-bold text-center mb-3">商品B</h2>
-      <%= form_with model: @purchase_b, url: new_step1_items_path, method: :get, scope: :purchase_b, class: "space-y-4 text-xs" do |f| %>
+      <%= form_with model: @purchase_b, url: new_item_registration_path, method: :get, scope: :purchase_b, class: "space-y-4 text-xs" do |f| %>
         <div>
           <%= f.label :content_quantity, "内容量" ,class: "text-black" %>
           <div class="mt-1 flex items-center border border-light-gray rounded-lg bg-white focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition">

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -7,7 +7,7 @@
       <span class="text-xs mt-1"><%= t('footer.index') %></span>
     <% end %>
 
-    <!--「商品比較画面」に遷移する内容（現在はURLを"#"としています） -->
+    <!--「商品比較画面」に遷移する内容 -->
     <%= link_to comparison_path, class: "flex flex-col items-center #{active_class('comparison')}" do %>
       <span class="material-symbols-outlined text-28">balance</span>
       <span class="text-xs mt-1"><%= t('footer.comparison') %></span>


### PR DESCRIPTION
### 関連ISSUE
---
close #265 

### 変更内容
---
- 比較画面の遷移のURLを変更しました。
- 

### 動作確認
---
- 購入履歴一覧の画面から比較画面へ問題なく遷移する
- 遷移する際、購入履歴の単価が比較画面に表示される
- フッターボタンから比較画面に遷移することができる

### 補足・レビュアーへのメモ
---