### PR TITLE
Perf/security headers

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,7 +10,7 @@
     <!-- Google Analytics（GA4）の導入 -->
     <!-- Google tag (gtag.js) -->
     <% if ENV['GA_TRACKING_ID'].present? %>
-      <scrip async src="https://www.googletagmanager.com/gtag/js?id=<%= ENV['GA_TRACKING_ID'] %>"></script>
+      <script async src="https://www.googletagmanager.com/gtag/js?id=<%= ENV['GA_TRACKING_ID'] %>"></script>
       <%= javascript_tag nonce: true do %>
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,14 +10,14 @@
     <!-- Google Analytics（GA4）の導入 -->
     <!-- Google tag (gtag.js) -->
     <% if ENV['GA_TRACKING_ID'].present? %>
-      <script async src="https://www.googletagmanager.com/gtag/js?id=G-JR413E9JP4"></script>
-      <script>
+      <scrip async src="https://www.googletagmanager.com/gtag/js?id=<%= ENV['GA_TRACKING_ID'] %>"></script>
+      <%= javascript_tag nonce: true do %>
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
 
         gtag('config', '<%= ENV['GA_TRACKING_ID'] %>');
-      </script>
+      <% end %>
     <% end %>
 
     <%= yield :head %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -48,7 +48,10 @@ Rails.application.configure do
   # Can be used together with config.force_ssl for Strict-Transport-Security and secure cookies.
   # config.assume_ssl = true
 
-  # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
+  # HTTPS強制化により、通信が暗号化
+  # ・HTTPでアクセスされてもHTTPSでリダイレクト
+  # ・CookieにSecure属性を自動付与（HTTPでは送信させない）
+  # ・HSTSヘッダーを自動送信(ブラウザが以後HTTPSを強制)
   config.force_ssl = true
 
   # Skip http-to-https redirect for the default health check endpoint.

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -22,7 +22,7 @@ Rails.application.configure do
   # CSP違反するインラインに対し、リクエストごとに使い捨ての許可証(nonce)を発行する設定
   config.content_security_policy_nonce_generator = ->(request) { SecureRandom.base64(16) }
   # nonce検証を有効にするディレクティブを指定(script-srcとstyle-srcのインラインを nonce で許可制に)
-  config.content_security_policy_nonce_directives = %w(script-src style-src)
+  config.content_security_policy_nonce_directives = %w[ script-src style-src ]
   #
   #  # Report violations without enforcing the policy.
   # config.content_security_policy_report_only = true

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -7,20 +7,22 @@
 # Content-Security-Policy（CSP）の設定
 # どこから読み込んだリソースなら実行・表示してよいかをブラウザに指示
 Rails.application.configure do
-  config.content_security_policy do |policy| # 自分のサイト（:self)、HTTPSの外部サイト(:https）
-    policy.default_src :self, :https         # 基本ルール：自分のサイトとHTTPSの外部サイトからの読み込みを許可
-    policy.font_src    :self, :https, :data  # フォントの読み込み
-    policy.img_src     :self, :https, :data  # 画像の読み込み
-    policy.object_src  :none                 # <object>、<embed>、<applet> というHTMLタグで何かを埋め込むのを完全禁止
-    policy.script_src  :self, :https         # JavaScriptの読み込み <==　XSSで最重要！！！
-    policy.style_src   :self, :https         # CSSの読み込み
+  config.content_security_policy do |policy|         # 自分のサイト（:self)、HTTPSの外部サイト(:https）
+    policy.default_src :self, :https                 # 基本ルール：自分のサイトとHTTPSの外部サイトからの読み込みを許可
+    policy.font_src    :self, :https, :data          # フォントの読み込み
+    policy.img_src     :self, :https, :data          # 画像の読み込み
+    policy.object_src  :none                         # <object>、<embed>、<applet> というHTMLタグで何かを埋め込むのを完全禁止
+    policy.script_src  :self, :https                 # JavaScriptの読み込み <==　XSSで最重要！！！
+    policy.style_src   :self, :https                 # CSSの読み込み
     # Specify URI for violation reports
     # policy.report_uri "/csp-violation-report-endpoint"
   end
   #
   #   # Generate session nonces for permitted importmap, inline scripts, and inline styles.
-  #   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
-  #   config.content_security_policy_nonce_directives = %w(script-src style-src)
+  # CSP違反するインラインに対し、リクエストごとに使い捨ての許可証(nonce)を発行する設定
+  config.content_security_policy_nonce_generator = ->(request) { SecureRandom.base64(16) }
+  # nonce検証を有効にするディレクティブを指定(script-srcとstyle-srcのインラインを nonce で許可制に)
+  config.content_security_policy_nonce_directives = %w(script-src style-src)
   #
   #  # Report violations without enforcing the policy.
   # config.content_security_policy_report_only = true

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -4,22 +4,24 @@
 # See the Securing Rails Applications Guide for more information:
 # https://guides.rubyonrails.org/security.html#content-security-policy-header
 
-# Rails.application.configure do
-#   config.content_security_policy do |policy|
-#     policy.default_src :self, :https
-#     policy.font_src    :self, :https, :data
-#     policy.img_src     :self, :https, :data
-#     policy.object_src  :none
-#     policy.script_src  :self, :https
-#     policy.style_src   :self, :https
-#     # Specify URI for violation reports
-#     # policy.report_uri "/csp-violation-report-endpoint"
-#   end
-#
-#   # Generate session nonces for permitted importmap, inline scripts, and inline styles.
-#   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
-#   config.content_security_policy_nonce_directives = %w(script-src style-src)
-#
-#   # Report violations without enforcing the policy.
-#   # config.content_security_policy_report_only = true
-# end
+# Content-Security-Policy（CSP）の設定
+# どこから読み込んだリソースなら実行・表示してよいかをブラウザに指示
+Rails.application.configure do
+  config.content_security_policy do |policy| # 自分のサイト（:self)、HTTPSの外部サイト(:https）
+    policy.default_src :self, :https         # 基本ルール：自分のサイトとHTTPSの外部サイトからの読み込みを許可
+    policy.font_src    :self, :https, :data  # フォントの読み込み
+    policy.img_src     :self, :https, :data  # 画像の読み込み
+    policy.object_src  :none                 # <object>、<embed>、<applet> というHTMLタグで何かを埋め込むのを完全禁止
+    policy.script_src  :self, :https         # JavaScriptの読み込み <==　XSSで最重要！！！
+    policy.style_src   :self, :https         # CSSの読み込み
+    # Specify URI for violation reports
+    # policy.report_uri "/csp-violation-report-endpoint"
+  end
+  #
+  #   # Generate session nonces for permitted importmap, inline scripts, and inline styles.
+  #   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
+  #   config.content_security_policy_nonce_directives = %w(script-src style-src)
+  #
+  #  # Report violations without enforcing the policy.
+  # config.content_security_policy_report_only = true
+end

--- a/config/initializers/permissions_policy.rb
+++ b/config/initializers/permissions_policy.rb
@@ -3,11 +3,13 @@
 # Define an application-wide HTTP permissions policy. For further
 # information see: https://developers.google.com/web/updates/2018/06/feature-policy
 
-# Rails.application.config.permissions_policy do |policy|
-#   policy.camera      :none
-#   policy.gyroscope   :none
-#   policy.microphone  :none
-#   policy.usb         :none
-#   policy.fullscreen  :self
-#   policy.payment     :self, "https://secure.example.com"
-# end
+# ブラウザの強い機能をこのアプリで使わせるかどうかの指示
+Rails.application.config.permissions_policy do |policy|
+  policy.camera      :none                                # カメラへのアクセスオフ
+  policy.gyroscope   :none                                # スマホの回転を検知するセンサーオフ
+  policy.microphone  :none                                # 音声入力オフ
+  policy.usb         :none                                # web USB API厳禁（ブラウザからUSB機器に直接アクセスできる仕組み）
+  policy.payment     :none # "https://secure.example.com" # ブラウザ統合の決済UIを呼び出す仕組みオフ
+  policy.geolocation :none                                # 【追加】位置情報取得オフ
+  policy.fullscreen  :self                                # このサイト自身だけフルスクリーンOK
+end


### PR DESCRIPTION
### 関連ISSUE
---
close #174 

### 変更内容
---
- 現状のセキュリティヘッダーを設定している項目を確認しました。
- その中で未設定の
  - Content-Security-Policy (CSP)
  - Permissions-Policy

を設定しました。

### 動作確認
---
- 開発ツールより、レスポンスヘッダーを確認し、追加した2項目が反映されている確認
- 本番環境では本プルリクエストマージ後に実施します。

### 補足・レビュアーへのメモ
---

プルリク前の対策済みセキュリティヘッダー
クリックジャッキング対策（x-frame-options: SAMEORIGIN ）
HSTS指示（strict-transport-security: max-age=63072000; includeSubDomains）
X-Content-Type-Options指示（x-content-type-options: nosniff）
Referrer-Policy（referrer-policy: strict-origin-when-corss-origin）

前日pushした内容が行方不明になったので、当日空commitでpushしました。

https://securityheaders.com/

<img width="1673" height="827" alt="image" src="https://github.com/user-attachments/assets/b8e571a8-f954-444e-a49b-aab46c2676c9" />

securityheaders.comで確認した結果、Aランク獲得
Permissions-Policyについては設定済みだが、Railsが古い名前のFeature-Policyから新しい名前のPermissions-Policyに移行中とのことで、レスポンスヘッダーにはFeature-Policyと表示される仕様になっている。

<img width="868" height="70" alt="image" src="https://github.com/user-attachments/assets/de385d4a-96d1-49f6-9624-e06abe296490" />
