### PR TITLE
feat: 各一覧画面の空状態のメッセージ表示（検索条件結果0件も含む）

### DIFF
--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -3,45 +3,71 @@
   arrow_back
 <% end %>
 <% content_for :title do %>
-  カテゴリマスタ
+  カテゴリー一覧
 <% end %>
 
-<div class="space-y-4">
-  <% @categories.each do |category| %>
-    <div class="swipe-card" data-controller="swipe" data-action="touchstart->swipe#touchstart touchend->swipe#touchend touchstart@document->swipe#outsideClick">
+<!-- 1件以上のカテゴリーが登録されている場合 -->
+<% if @categories.any? %>
+  <div class="space-y-4">
+    <% @categories.each do |category| %>
+      <div class="swipe-card" data-controller="swipe" data-action="touchstart->swipe#touchstart touchend->swipe#touchend touchstart@document->swipe#outsideClick">
 
-      <%# カテゴリ名：常に左端に固定表示 %>
-      <div class="absolute top-0 left-0 bottom-0 flex items-center px-5 z-10">
-        <span class="text-sm font-bold text-gray-800"><%= category.name %></span>
+        <%# カテゴリ名：常に左端に固定表示 %>
+        <div class="absolute top-0 left-0 bottom-0 flex items-center px-5 z-10">
+          <span class="text-sm font-bold text-gray-800"><%= category.name %></span>
+        </div>
+
+        <%# カードリンク（スライドする層）：右側に配置 %>
+        <div class="swipe-inner" data-swipe-target="inner">
+          <span class="material-symbols-outlined text-gray-300 text-sm">keyboard_double_arrow_right</span>
+        </div>
+
+        <%# アクションボタン %>
+        <div class="swipe-actions" data-swipe-target="actions" style="transform: translateX(100%);">
+
+          <%= link_to "編集", edit_category_path(category),
+                data: { action: "touchend->swipe#stopPropagation" },
+                class: "flex items-center justify-center w-16
+                        bg-blue-400 text-white text-xs font-medium self-stretch" %>
+
+          <%= link_to "削除", category_path(category),
+                data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？", action: "touchend->swipe#stopPropagation" },
+                class: "flex items-center justify-center w-16
+                        bg-red-400 text-white text-xs font-medium
+                        border-none cursor-pointer h-full" %>
+        </div>
       </div>
+    <% end %>
+  </div>
+  <%# 商品登録ボタン（FAB） %>
+  <div class="fixed bottom-28 left-0 right-0 mx-auto max-w-xl px-6 flex justify-end z-25">
+    <%= link_to new_category_path, class: "card bg-primary text-white px-6 py-4 rounded-full flex items-center font-bold", data: { controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" } do %>
+      <span class="text-lg">カテゴリー追加</span>
+      <span class="material-symbols-outlined">add</span>
+    <% end %>
+  </div>
 
-      <%# カードリンク（スライドする層）：右側に配置 %>
-      <div class="swipe-inner" data-swipe-target="inner">
-        <span class="material-symbols-outlined text-gray-300 text-sm">keyboard_double_arrow_right</span>
-      </div>
-
-      <%# アクションボタン %>
-      <div class="swipe-actions" data-swipe-target="actions" style="transform: translateX(100%);">
-
-        <%= link_to "編集", edit_category_path(category),
-              data: { action: "touchend->swipe#stopPropagation" },
-              class: "flex items-center justify-center w-16
-                      bg-blue-400 text-white text-xs font-medium self-stretch" %>
-
-        <%= link_to "削除", category_path(category),
-              data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？", action: "touchend->swipe#stopPropagation" },
-              class: "flex items-center justify-center w-16
-                      bg-red-400 text-white text-xs font-medium
-                      border-none cursor-pointer h-full" %>
-      </div>
+<!-- カテゴリー登録が0件の場合 -->
+<% else %>
+  <div class="flex flex-col items-center text-center py-8">
+    <h1 class="text-3xl font-bold text-black mb-4">
+      カテゴリーがありません
+    </h1>
+    <div class="mb-4 flex h-32 w-32 items-center justify-center rounded-full bg-light-gray">
+      <span class="material-symbols-outlined text-dark-gray" style="font-size: 80px;">category</span>
     </div>
-  <% end %>
-</div>
-<%# 商品登録ボタン（FAB） %>
-<div class="fixed bottom-28 left-0 right-0 mx-auto max-w-xl px-6 flex justify-end z-25">
-  <%= link_to new_category_path, class: "card bg-primary text-white px-6 py-4 rounded-full flex items-center font-bold", data: { controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" } do %>
-    <span class="text-lg">カテゴリ追加</span>
-    <span class="material-symbols-outlined">add</span>
-  <% end %>
-</div>
+    <p class="text-dark-gray mb-8">
+      食材・日用品・調味料など、<br>
+      よく使うカテゴリーを登録しましょう
+    </p>
+
+    <!-- 商品登録遷移ボタン -->
+    <div class="w-full px-6 mb-8">
+      <%= link_to new_store_path, class: "card bg-primary text-white px-6 py-4 rounded-full flex items-center justify-center font-bold", data: { controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" } do %>
+        <span class="text-xl tracking-widest">カテゴリーを登録する</span>
+        <span class="material-symbols-outlined">add_2</span>
+      <% end %>
+    </div>
+  </div>
+<% end %>
 

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -63,7 +63,7 @@
 
     <!-- 商品登録遷移ボタン -->
     <div class="w-full px-6 mb-8">
-      <%= link_to new_store_path, class: "card bg-primary text-white px-6 py-4 rounded-full flex items-center justify-center font-bold", data: { controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" } do %>
+      <%= link_to new_category_path, class: "card bg-primary text-white px-6 py-4 rounded-full flex items-center justify-center font-bold", data: { controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" } do %>
         <span class="text-xl tracking-widest">カテゴリーを登録する</span>
         <span class="material-symbols-outlined">add_2</span>
       <% end %>

--- a/app/views/content_units/index.html.erb
+++ b/app/views/content_units/index.html.erb
@@ -3,45 +3,71 @@
   arrow_back
 <% end %>
 <% content_for :title do %>
-  内容量単位マスタ
+  内容量単位一覧
 <% end %>
 
-<div class="space-y-4">
-  <% @content_units.each do |content_unit| %>
-    <div class="swipe-card" data-controller="swipe" data-action="touchstart->swipe#touchstart touchend->swipe#touchend touchstart@document->swipe#outsideClick">
+<!-- 1件以上の内容量単位が登録されている場合 -->
+<% if @content_units.any? %>
 
-      <%# カテゴリ名：常に左端に固定表示 %>
-      <div class="absolute top-0 left-0 bottom-0 flex items-center px-5 z-10">
-        <span class="text-sm font-bold text-gray-800"><%= content_unit.name %></span>
+  <div class="space-y-4">
+    <% @content_units.each do |content_unit| %>
+      <div class="swipe-card" data-controller="swipe" data-action="touchstart->swipe#touchstart touchend->swipe#touchend touchstart@document->swipe#outsideClick">
+
+        <%# カテゴリ名：常に左端に固定表示 %>
+        <div class="absolute top-0 left-0 bottom-0 flex items-center px-5 z-10">
+          <span class="text-sm font-bold text-gray-800"><%= content_unit.name %></span>
+        </div>
+
+        <%# カードリンク（スライドする層）：右側に配置 %>
+        <div class="swipe-inner" data-swipe-target="inner">
+          <span class="material-symbols-outlined text-gray-300 text-sm">keyboard_double_arrow_right</span>
+        </div>
+
+        <%# アクションボタン %>
+        <div class="swipe-actions" data-swipe-target="actions" style="transform: translateX(100%);">
+
+          <%= link_to "編集", edit_content_unit_path(content_unit),
+                data: { action: "touchend->swipe#stopPropagation" },
+                class: "flex items-center justify-center w-16
+                        bg-blue-400 text-white text-xs font-medium self-stretch" %>
+
+          <%= link_to "削除", content_unit_path(content_unit),
+                data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？", action: "touchend->swipe#stopPropagation" },
+                class: "flex items-center justify-center w-16
+                        bg-red-400 text-white text-xs font-medium
+                        border-none cursor-pointer h-full" %>
+        </div>
       </div>
+    <% end %>
+  </div>
+  <%# 商品登録ボタン（FAB） %>
+  <div class="fixed bottom-28 left-0 right-0 mx-auto max-w-xl px-6 flex justify-end z-25">
+    <%= link_to new_content_unit_path, class: "card bg-primary text-white px-6 py-4 rounded-full flex items-center font-bold", data: { controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" } do %>
+      <span class="text-lg">内容量単位追加</span>
+      <span class="material-symbols-outlined">add</span>
+    <% end %>
+  </div>
 
-      <%# カードリンク（スライドする層）：右側に配置 %>
-      <div class="swipe-inner" data-swipe-target="inner">
-        <span class="material-symbols-outlined text-gray-300 text-sm">keyboard_double_arrow_right</span>
-      </div>
-
-      <%# アクションボタン %>
-      <div class="swipe-actions" data-swipe-target="actions" style="transform: translateX(100%);">
-
-        <%= link_to "編集", edit_content_unit_path(content_unit),
-              data: { action: "touchend->swipe#stopPropagation" },
-              class: "flex items-center justify-center w-16
-                      bg-blue-400 text-white text-xs font-medium self-stretch" %>
-
-        <%= link_to "削除", content_unit_path(content_unit),
-              data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？", action: "touchend->swipe#stopPropagation" },
-              class: "flex items-center justify-center w-16
-                      bg-red-400 text-white text-xs font-medium
-                      border-none cursor-pointer h-full" %>
-      </div>
+<!-- 内容量単位登録が0件の場合 -->
+<% else %>
+  <div class="flex flex-col items-center text-center py-8">
+    <h1 class="text-3xl font-bold text-black mb-4">
+      内容量単位がありません
+    </h1>
+    <div class="mb-4 flex h-32 w-32 items-center justify-center rounded-full bg-light-gray">
+      <span class="material-symbols-outlined text-dark-gray" style="font-size: 80px;">speed</span>
     </div>
-  <% end %>
-</div>
-<%# 商品登録ボタン（FAB） %>
-<div class="fixed bottom-28 left-0 right-0 mx-auto max-w-xl px-6 flex justify-end z-25">
-  <%= link_to new_content_unit_path, class: "card bg-primary text-white px-6 py-4 rounded-full flex items-center font-bold", data: { controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" } do %>
-    <span class="text-lg">内容量単位追加</span>
-    <span class="material-symbols-outlined">add</span>
-  <% end %>
-</div>
+    <p class="text-dark-gray mb-8">
+      「g」「ml」「個」など、<br>
+      よく使う単位を登録しましょう
+    </p>
 
+    <!-- 商品登録遷移ボタン -->
+    <div class="w-full px-6 mb-8">
+      <%= link_to new_content_unit_path, class: "card bg-primary text-white px-6 py-4 rounded-full flex items-center justify-center font-bold", data: { controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" } do %>
+        <span class="text-xl tracking-widest">内容量単位を登録する</span>
+        <span class="material-symbols-outlined">add_2</span>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -35,23 +35,23 @@
   <!-- 検索した結果、商品がない場合 -->
   <% if @items.empty? %>
     <div class="flex flex-col items-center text-center py-12">
-      <span class="material-symbols-outlined mb-5 text-middle-gray" style="font-size: 80px;">search_off</span>
-      <h2 class="text-lg font-bold text-gray-600 mb-2">
+      <span class="material-symbols-outlined mb-12 text-dark-gray" style="font-size: 80px;">search_off</span>
+      <h1 class="text-3xl font-bold text-black mb-4">
         検索した結果、見つかりませんでした
-      </h2>
-      <p class="text-sm text-gray-400 mb-6">
+      </h1>
+      <p class="text-dark-gray mb-8">
         この商品はまだ登録されていない可能性があります
       </p>
 
       <!-- 商品登録遷移ボタン -->
-      <div class="w-full p-6">
+      <div class="w-full px-6 mb-8">
         <%= link_to new_item_registration_path, class: "card bg-primary text-white px-6 py-4 rounded-full flex items-center justify-center font-bold", data: { controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" } do %>
-          <span class="text-lg">商品を登録する</span>
-          <span class="material-symbols-outlined">add</span>
+          <span class="text-xl tracking-widest">商品を登録する</span>
+          <span class="material-symbols-outlined">add_2</span>
         <% end %>
       </div>
 
-      <%= link_to "検索条件をリセット", items_path, class: "text-lg link text-primary font-bold" %>
+      <%= link_to "検索条件をリセット", items_path, class: "tracking-widest text-xl link text-primary font-bold" %>
     </div>
 
   <!-- 検索した結果、商品がある場合 -->
@@ -130,23 +130,29 @@
     </div>
   <% end %>
 
-<!-- itemにデータがない場合の誘導表示 -->
+<!-- 商品登録が0件の場合 -->
 <% else %>
-  <main class="flex flex-1 flex-col items-center justify-center px-6 py-12">
-    <div class="w-full max-w-sm flex flex-col items-center text-center">
-      <div class="mb-8 flex h-24 w-24 items-center justify-center rounded-full bg-secondary/10">
-        <span class="material-symbols-outlined text-secondary text-5xl">add</span>
-      </div>
-      <div class="mb-10 space-y-3">
-        <h2 class="text-2xl font-bold tracking-tight text-black">データがありません</h2>
-        <p class="text-middle-gray text-sm leading-relaxed max-w-[240px] mx-auto">
-          まだ登録されている商品はありません。最初のステップを始めましょう。
-        </p>
-      </div>
-      <%= link_to new_item_registration_path, class: "flex w-full items-center justify-center gap-2 rounded-xl bg-primary py-4 px-8 text-white font-bold transition-transform active:scale-95" do %>
-        <span class="material-symbols-outlined text-xl">add</span>
-        <span>商品を登録する</span>
+  <div class="flex flex-col items-center text-center py-8">
+    <h1 class="text-3xl font-bold text-black mb-4">
+      商品を登録しましょう
+    </h1>
+    <div class="mb-4 flex h-32 w-32 items-center justify-center rounded-full bg-light-gray">
+      <span class="material-symbols-outlined text-dark-gray" style="font-size: 80px;">add_shopping_cart</span>
+    </div>
+    <p class="text-dark-gray mb-8">
+      よく買う商品の価格を記録して、<br>
+      賢く節約を始めましょう
+    </p>
+
+    <!-- 商品登録遷移ボタン -->
+    <div class="w-full px-6 mb-8">
+      <%= link_to new_item_registration_path, class: "card bg-primary text-white px-6 py-4 rounded-full flex items-center justify-center font-bold", data: { controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" } do %>
+        <span class="text-xl tracking-widest">商品を登録する</span>
+        <span class="material-symbols-outlined">add_2</span>
       <% end %>
     </div>
-  </main>
+
+    <!-- 使い方説明リンク -->
+    <%= link_to "使い方を見る", "#", class: "tracking-widest text-xl link text-primary font-bold" %>
+  </div>
 <% end %>

--- a/app/views/purchases/index.html.erb
+++ b/app/views/purchases/index.html.erb
@@ -77,8 +77,8 @@
     </div>
   <% end %>
   <div class="flex justify-between items-center mb-5">
-    <h2 class="text-xl font-bold text-middle-gray">購入履歴</h2>
-    <div class="flex gap-4 text-xl text-middle-gray">
+    <h2 class="text-xl font-bold text-dark-gray">購入履歴</h2>
+    <div class="flex gap-4 text-xl text-dark-gray">
       <span class="underline underline-offset-4"><%= sort_link(@q, :unit_price, "単価") %></span>
       <span class="underline underline-offset-4"><%= sort_link(@q, :purchased_on, "購入日")%></span>
     </div>
@@ -96,102 +96,128 @@
       </div>
     <% end %>
   </div>
+  
+  <!-- 検索した結果、登録している店舗がない場合 -->
+  <% if @purchases.empty? %>
+    <div class="flex flex-col items-center text-center py-12">
+      <span class="material-symbols-outlined mb-12 text-dark-gray" style="font-size: 80px;">search_off</span>
+      <h1 class="text-3xl font-bold text-black mb-4">
+        検索した結果、見つかりませんでした
+      </h1>
+      <p class="text-dark-gray mb-8">
+        この店舗はまだ登録されていない可能性があります
+      </p>
 
-  <div class="space-y-2">
-    <% @purchases.each do |purchase| %>
-      <% is_lowest = purchase.id == @lowest_purchase&.id %>
-      <div class="swipe-card" data-controller="swipe" data-action="touchstart->swipe#touchstart touchend->swipe#touchend touchstart@document->swipe#outsideClick">
-
-        <!-- 左側の緑ボーダー線の固定 -->
-        <div class="absolute left-0 top-0 bottom-0 w-1.5 z-30 <%= is_lowest ? 'bg-accent' : 'bg-primary' %> rounded-l-2xl"></div>
-
-        <!-- テキスト部分の固定 -->
-        <div class="absolute left-3 top-0 bottom-0 right-10 flex flex-col justify-center py-4 px-2 z-10">
-          <div class="flex items-center justify-between mb-2">
-
-            <!-- 日付表示 -->
-            <span class="text-xs text-middle-gray"><%= purchase.purchased_on %></span>
-
-            <!-- 最安値バッジ表示 -->
-            <% if is_lowest %>
-              <div class="inline-flex items-center gap-1 bg-accent/10 text-accent rounded-full px-2 py-0.5 text-xs font-medium">
-                <span class="material-symbols-outlined text-xs">star</span>
-                最安値
-              </div>
-            <% end %>
-          </div>
-
-          <!-- 単価表示 -->
-          <div class="flex items-baseline gap-1 mb-0">
-            <span class="text-2xl font-bold <%= is_lowest ? 'text-accent' : 'text-primary' %> leading-none"><%= purchase.unit_price %></span>
-            <span class="text-xs <%= is_lowest ? 'text-accent' : 'text-middle-gray' %>">円/<%= purchase.content_unit.name %></span>
-          </div>
-          <hr class="border-t border-light-gray my-2">
-
-          <!-- 店舗名・量・単位・価格 -->
-          <div class="flex items-center flex-wrap gap-2">
-            <% if purchase.store.present? %>
-              <span class="<%= is_lowest ? 'bg-accent/10 text-accent' : 'bg-primary/10 text-primary' %> rounded-full px-3 py-0.5 text-xs"><%= purchase.store.name %></span>
-            <% end %>
-            <% if purchase.brand.present? %>
-              <span class="text-xs text-middle-gray"><%= purchase.brand %></span>
-            <% end %>
-            <% if purchase.pack_unit.present? %>
-              <span class="text-xs text-black"><%= purchase.pack_quantity %><%= purchase.pack_unit.name %> × <%= purchase.content_quantity %><%= purchase.content_unit.name %> · ¥<%= purchase.price %></span>
-            <% elsif purchase.pack_quantity > 1 %>
-              <span class="text-xs text-black"><%= purchase.pack_quantity %> × <%= purchase.content_quantity %><%= purchase.content_unit.name %> · ¥<%= purchase.price %></span>
-            <% else %>
-              <span class="text-xs text-black"><%= purchase.content_quantity %><%= purchase.content_unit.name %> · ¥<%= purchase.price %></span>
-            <% end %>
-          </div>
-        </div>
-
-        <!-- swipe-inner：アイコンのみ・スライドする層 -->
-        <div class="swipe-inner rounded-2xl <%= is_lowest ? 'border border-accent' : 'border border-light-gray' %>" style="min-height: 8rem;" data-swipe-target="inner">
-          <span class="material-symbols-outlined text-light-gray text-sm">keyboard_double_arrow_right</span>
-        </div>
-
-        <!-- スライドした時に表示される層 -->
-        <div class="swipe-actions" data-swipe-target="actions" style="transform: translateX(100%);">
-          <%= link_to edit_item_purchase_path(@item, purchase),
-                data: { action: "touchend->swipe#stopPropagation" },
-                class: "flex items-center justify-center w-16 bg-blue-400 text-white text-xs font-medium self-stretch" do %>
-            <span class="material-symbols-outlined" style="font-size:18px;">edit</span>
-          <% end %>
-          <%= link_to item_purchase_path(@item, purchase),
-                data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？", action: "touchend->swipe#stopPropagation" },
-                class: "flex items-center justify-center w-16 bg-red-400 text-white text-xs font-medium border-none cursor-pointer h-full" do %>
-            <span class="material-symbols-outlined" style="font-size:18px;">delete</span>
-          <% end %>
-        </div>
+      <!-- 商品登録遷移ボタン -->
+      <div class="w-full px-6 mb-8">
+        <%= link_to new_item_registration_path, class: "card bg-primary text-white px-6 py-4 rounded-full flex items-center justify-center font-bold", data: { controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" } do %>
+          <span class="text-xl tracking-widest">商品を登録する</span>
+          <span class="material-symbols-outlined">add_2</span>
+        <% end %>
       </div>
-    <% end %>
-  </div>
+
+      <%= link_to "検索条件をリセット", item_purchases_path(@item), class: "tracking-widest text-xl link text-primary font-bold" %>
+    </div>
+
+  <!-- 検索した結果、登録している店舗がある場合 -->
+  <% else %>
+    <div class="space-y-2">
+      <% @purchases.each do |purchase| %>
+        <% is_lowest = purchase.id == @lowest_purchase&.id %>
+        <div class="swipe-card" data-controller="swipe" data-action="touchstart->swipe#touchstart touchend->swipe#touchend touchstart@document->swipe#outsideClick">
+
+          <!-- 左側の緑ボーダー線の固定 -->
+          <div class="absolute left-0 top-0 bottom-0 w-1.5 z-30 <%= is_lowest ? 'bg-accent' : 'bg-primary' %> rounded-l-2xl"></div>
+
+          <!-- テキスト部分の固定 -->
+          <div class="absolute left-3 top-0 bottom-0 right-10 flex flex-col justify-center py-4 px-2 z-10">
+            <div class="flex items-center justify-between mb-2">
+
+              <!-- 日付表示 -->
+              <span class="text-xs text-middle-gray"><%= purchase.purchased_on %></span>
+
+              <!-- 最安値バッジ表示 -->
+              <% if is_lowest %>
+                <div class="inline-flex items-center gap-1 bg-accent/10 text-accent rounded-full px-2 py-0.5 text-xs font-medium">
+                  <span class="material-symbols-outlined text-xs">star</span>
+                  最安値
+                </div>
+              <% end %>
+            </div>
+
+            <!-- 単価表示 -->
+            <div class="flex items-baseline gap-1 mb-0">
+              <span class="text-2xl font-bold <%= is_lowest ? 'text-accent' : 'text-primary' %> leading-none"><%= purchase.unit_price %></span>
+              <span class="text-xs <%= is_lowest ? 'text-accent' : 'text-middle-gray' %>">円/<%= purchase.content_unit.name %></span>
+            </div>
+            <hr class="border-t border-light-gray my-2">
+
+            <!-- 店舗名・量・単位・価格 -->
+            <div class="flex items-center flex-wrap gap-2">
+              <% if purchase.store.present? %>
+                <span class="<%= is_lowest ? 'bg-accent/10 text-accent' : 'bg-primary/10 text-primary' %> rounded-full px-3 py-0.5 text-xs"><%= purchase.store.name %></span>
+              <% end %>
+              <% if purchase.brand.present? %>
+                <span class="text-xs text-middle-gray"><%= purchase.brand %></span>
+              <% end %>
+              <% if purchase.pack_unit.present? %>
+                <span class="text-xs text-black"><%= purchase.pack_quantity %><%= purchase.pack_unit.name %> × <%= purchase.content_quantity %><%= purchase.content_unit.name %> · ¥<%= purchase.price %></span>
+              <% elsif purchase.pack_quantity > 1 %>
+                <span class="text-xs text-black"><%= purchase.pack_quantity %> × <%= purchase.content_quantity %><%= purchase.content_unit.name %> · ¥<%= purchase.price %></span>
+              <% else %>
+                <span class="text-xs text-black"><%= purchase.content_quantity %><%= purchase.content_unit.name %> · ¥<%= purchase.price %></span>
+              <% end %>
+            </div>
+          </div>
+
+          <!-- swipe-inner：アイコンのみ・スライドする層 -->
+          <div class="swipe-inner rounded-2xl <%= is_lowest ? 'border border-accent' : 'border border-light-gray' %>" style="min-height: 8rem;" data-swipe-target="inner">
+            <span class="material-symbols-outlined text-light-gray text-sm">keyboard_double_arrow_right</span>
+          </div>
+
+          <!-- スライドした時に表示される層 -->
+          <div class="swipe-actions" data-swipe-target="actions" style="transform: translateX(100%);">
+            <%= link_to edit_item_purchase_path(@item, purchase),
+                  data: { action: "touchend->swipe#stopPropagation" },
+                  class: "flex items-center justify-center w-16 bg-blue-400 text-white text-xs font-medium self-stretch" do %>
+              <span class="material-symbols-outlined" style="font-size:18px;">edit</span>
+            <% end %>
+            <%= link_to item_purchase_path(@item, purchase),
+                  data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？", action: "touchend->swipe#stopPropagation" },
+                  class: "flex items-center justify-center w-16 bg-red-400 text-white text-xs font-medium border-none cursor-pointer h-full" do %>
+              <span class="material-symbols-outlined" style="font-size:18px;">delete</span>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
 
 <!-- 商品に対して購入履歴が0件の場合 -->
 <% else %>
   <div class="flex flex-col items-center text-center py-8">
-    <h1 class="text-lg font-bold text-gray-600 mb-4">
-      <%= @item.name %>の購入履歴がありません
+    <h1 class="text-3xl font-bold text-black mb-2">
+      購入履歴がありません
     </h1>
+    <p class="text-black text-xl mb-4">
+      商品名：<%= @item.name %>
+    </p>
     <div class="mb-4 flex h-32 w-32 items-center justify-center rounded-full bg-light-gray">
       <span class="material-symbols-outlined text-dark-gray" style="font-size: 80px;">receipt_long_off</span>
     </div>
-    <p class="text-sm text-gray-400">
-      購入履歴を登録するか、
-    </p>
-    <p class="text-sm text-gray-400 mb-8">
+    <p class="text-dark-gray mb-8">
+      購入履歴を登録するか、<br>
       不要であれば商品ごと削除できます
     </p>
     
     <!-- 商品登録・商品削除遷移ボタン -->
     <div class="w-full px-6 space-y-3">
       <%= link_to new_item_registration_path, class: "card bg-primary text-white px-6 py-4 rounded-full flex items-center justify-center font-bold", data: { controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" } do %>
-        <span class="text-lg">購入履歴を登録する</span>
-        <span class="material-symbols-outlined">add</span>
+        <span class="text-xl tracking-widest">購入履歴を登録する</span>
+        <span class="material-symbols-outlined">add_2</span>
       <% end %>
       <%= button_to item_path(@item), method: :delete, form: { data: { turbo_confirm: "「#{@item.name}」を本当に削除しますか?" } }, class: "w-full card bg-white text-error px-6 py-4 border-2 border-error rounded-full flex items-center justify-center font-bold", data: { controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" } do %>
-        <span class="text-lg">この商品を削除する</span>
+        <span class="text-xl tracking-widest">この商品を削除する</span>
       <% end %>
     </div>
   </div>

--- a/app/views/setting/index.html.erb
+++ b/app/views/setting/index.html.erb
@@ -24,13 +24,13 @@
   <section>
     <p class="font-bold text-primary mb-2 px-1">マスタ管理</p>
     <div class="bg-white rounded-2xl shadow-sm ring ring-light-gray">
-      <!-- カテゴリマスタ -->
+      <!-- カテゴリーマスタ -->
       <%= link_to categories_path, class: "card shadow-none flex items-center gap-4 p-4 rounded-t-2xl hover:bg-light-gray hover:shadow-lg active:shadow-sm transition", data: { controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" } do %>
         <div class="w-10 h-10 rounded-full bg-primary/20 flex items-center justify-center text-primary">
           <span class="material-symbols-outlined text-xl">category</span>
         </div>
         <div class="flex-1">
-          <p class="font-bold text-text-base text-sm">カテゴリ管理</p>
+          <p class="font-bold text-text-base text-sm">カテゴリー管理</p>
         </div>
         <span class="material-symbols-outlined text-middle-gray">chevron_right</span>
       <% end %>
@@ -38,7 +38,7 @@
       <!-- 店舗マスタ -->
       <%= link_to stores_path, class: "card shadow-none flex items-center gap-4 p-4 hover:bg-light-gray hover:shadow-lg active:shadow-sm transition", data: { controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" } do %>
         <div class="w-10 h-10 rounded-full bg-primary/20 flex items-center justify-center text-primary">
-          <span class="material-symbols-outlined text-xl">privacy_tip</span>
+          <span class="material-symbols-outlined text-xl">storefront</span>
         </div>
         <p class="flex-1 font-bold text-text-base text-sm">店舗管理</p>
         <span class="material-symbols-outlined text-middle-gray">chevron_right</span>

--- a/app/views/stores/index.html.erb
+++ b/app/views/stores/index.html.erb
@@ -3,36 +3,63 @@
   arrow_back
 <% end %>
 <% content_for :title do %>
-  店舗マスタ
+  店舗一覧
 <% end %>
 
-<div class="space-y-4">
-  <% @stores.each do |store| %>
-    <div class="swipe-card" data-controller="swipe" data-action="touchstart->swipe#touchstart touchend->swipe#touchend touchstart@document->swipe#outsideClick">
+<!-- 1件以上の店舗が登録されている場合 -->
+<% if @stores.any? %>
 
-      <%# 店舗名：常に左端に固定表示 %>
-      <div class="absolute top-0 left-0 bottom-0 flex items-center px-5 z-10">
-        <span class="text-sm font-bold text-gray-800"><%= store.name %></span>
+  <div class="space-y-4">
+    <% @stores.each do |store| %>
+      <div class="swipe-card" data-controller="swipe" data-action="touchstart->swipe#touchstart touchend->swipe#touchend touchstart@document->swipe#outsideClick">
+
+        <%# 店舗名：常に左端に固定表示 %>
+        <div class="absolute top-0 left-0 bottom-0 flex items-center px-5 z-10">
+          <span class="text-sm font-bold text-gray-800"><%= store.name %></span>
+        </div>
+
+        <%# カードリンク（スライドする層）：右側に配置 %>
+        <div class="swipe-inner" data-swipe-target="inner">
+          <span class="material-symbols-outlined text-gray-300 text-sm">keyboard_double_arrow_right</span>
+        </div>
+
+        <%# アクションボタン %>
+        <div class="swipe-actions" data-swipe-target="actions" style="transform: translateX(100%);">
+
+          <%= link_to "編集", edit_store_path(store), data: { action: "touchend->swipe#stopPropagation" }, class: "flex items-center justify-center w-16 bg-blue-400 text-white text-xs font-medium self-stretch" %>
+          <%= link_to "削除", store_path(store), data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？", action: "touchend->swipe#stopPropagation" }, class: "flex items-center justify-center w-16 bg-red-400 text-white text-xs font-medium border-none cursor-pointer h-full" %>
+        </div>
       </div>
+    <% end %>
+  </div>
+  <%# 商品登録ボタン（FAB） %>
+  <div class="fixed bottom-28 left-0 right-0 mx-auto max-w-xl px-6 flex justify-end z-25">
+    <%= link_to new_store_path, class: "card bg-primary text-white px-6 py-4 rounded-full flex items-center font-bold", data: { controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" } do %>
+      <span class="text-lg">店舗追加</span>
+      <span class="material-symbols-outlined">add</span>
+    <% end %>
+  </div>
 
-      <%# カードリンク（スライドする層）：右側に配置 %>
-      <div class="swipe-inner" data-swipe-target="inner">
-        <span class="material-symbols-outlined text-gray-300 text-sm">keyboard_double_arrow_right</span>
-      </div>
-
-      <%# アクションボタン %>
-      <div class="swipe-actions" data-swipe-target="actions" style="transform: translateX(100%);">
-
-        <%= link_to "編集", edit_store_path(store), data: { action: "touchend->swipe#stopPropagation" }, class: "flex items-center justify-center w-16 bg-blue-400 text-white text-xs font-medium self-stretch" %>
-        <%= link_to "削除", store_path(store), data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？", action: "touchend->swipe#stopPropagation" }, class: "flex items-center justify-center w-16 bg-red-400 text-white text-xs font-medium border-none cursor-pointer h-full" %>
-      </div>
+<!-- 店舗登録が0件の場合 -->
+<% else %>
+  <div class="flex flex-col items-center text-center py-8">
+    <h1 class="text-3xl font-bold text-black mb-4">
+      店舗がありません
+    </h1>
+    <div class="mb-4 flex h-32 w-32 items-center justify-center rounded-full bg-light-gray">
+      <span class="material-symbols-outlined text-dark-gray" style="font-size: 80px;">storefront</span>
     </div>
-  <% end %>
-</div>
-<%# 商品登録ボタン（FAB） %>
-<div class="fixed bottom-28 left-0 right-0 mx-auto max-w-xl px-6 flex justify-end z-25">
-  <%= link_to new_store_path, class: "card bg-primary text-white px-6 py-4 rounded-full flex items-center font-bold", data: { controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" } do %>
-    <span class="text-lg">店舗追加</span>
-    <span class="material-symbols-outlined">add</span>
-  <% end %>
-</div>
+    <p class="text-dark-gray mb-8">
+      〇〇スーパー〇〇店など、<br>
+      よく使う店舗を登録しましょう
+    </p>
+
+    <!-- 商品登録遷移ボタン -->
+    <div class="w-full px-6 mb-8">
+      <%= link_to new_store_path, class: "card bg-primary text-white px-6 py-4 rounded-full flex items-center justify-center font-bold", data: { controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" } do %>
+        <span class="text-xl tracking-widest">店舗を登録する</span>
+        <span class="material-symbols-outlined">add_2</span>
+      <% end %>
+    </div>
+  </div>
+<% end %>


### PR DESCRIPTION
### 関連ISSUE
---
close #171 

### 変更内容
---
- 全ての一覧画面において、データ0件の時の、メッセージと登録ボタンを実装しました。
- 検索機能を実装している商品一覧と購入履歴一覧において、検索時0件だった時のメッセージと登録ボタンを実装しました。

### 動作確認
---
- ユーザー新規登録すると、全てデータ0件なので各一覧画面に遷移してメッセージの確認
- 商品登録後、検索機能がある商品一覧と購入履歴一覧画面でわざと範囲外の検索をすると0件時のメッセージが表示

### 補足・レビュアーへのメモ
---
商品登録一覧の0件時、最後に「使い方を見る」リンクを設置
まだ詳細を実装していないため、現在は"#"にして遷移できないようにしています。