### PR TITLE
利用規約・プライバシーポリシーページの作成と同意機能を実装

### DIFF
--- a/app/controllers/privacy_policy_controller.rb
+++ b/app/controllers/privacy_policy_controller.rb
@@ -1,0 +1,3 @@
+class PrivacyPolicyController < ApplicationController
+  def index; end
+end

--- a/app/controllers/privacy_policy_controller.rb
+++ b/app/controllers/privacy_policy_controller.rb
@@ -1,3 +1,6 @@
 class PrivacyPolicyController < ApplicationController
+  # トップ画面でも表示するため、ログインスキップのコールバック
+  skip_before_action :authenticate_user!, only: [ :index ]
+
   def index; end
 end

--- a/app/controllers/terms_controller.rb
+++ b/app/controllers/terms_controller.rb
@@ -1,0 +1,3 @@
+class TermsController < ApplicationController
+  def index; end
+end

--- a/app/controllers/terms_controller.rb
+++ b/app/controllers/terms_controller.rb
@@ -1,6 +1,6 @@
 class TermsController < ApplicationController
   # トップ画面でも表示するため、ログインスキップのコールバック
   skip_before_action :authenticate_user!, only: [ :index ]
-  
+
   def index; end
 end

--- a/app/controllers/terms_controller.rb
+++ b/app/controllers/terms_controller.rb
@@ -1,3 +1,6 @@
 class TermsController < ApplicationController
+  # トップ画面でも表示するため、ログインスキップのコールバック
+  skip_before_action :authenticate_user!, only: [ :index ]
+  
   def index; end
 end

--- a/app/helpers/privacy_policy_helper.rb
+++ b/app/helpers/privacy_policy_helper.rb
@@ -1,0 +1,2 @@
+module PrivacyPolicyHelper
+end

--- a/app/helpers/terms_helper.rb
+++ b/app/helpers/terms_helper.rb
@@ -1,0 +1,2 @@
+module TermsHelper
+end

--- a/app/views/home/top.html.erb
+++ b/app/views/home/top.html.erb
@@ -103,6 +103,6 @@
       <span>と</span>
       <%= link_to "プライバシーポリシー", privacy_policy_path, class: "font-bold link text-primary whitespace-nowrap" %>
     </div>
-    <p>© 2026 SokoNote</p>
+    <p>© <%= Time.current.year %> SokoNote</p>
   </div>
 </footer>

--- a/app/views/home/top.html.erb
+++ b/app/views/home/top.html.erb
@@ -94,3 +94,15 @@
     </div>
   </section>
 </main>
+
+<!-- フッター（利用規約・プライバシーポリシー・著作権マーク） -->
+<footer class="bg-white border-t border-slate-200 dark:border-slate-700 py-8 px-4">
+  <div class="max-w-screen-xl mx-auto flex flex-col items-center gap-4 text-sm text-slate-600 dark:text-slate-400">
+    <div class="flex flex-wrap items-center justify-center gap-x-2 gap-y-1">
+      <%= link_to "利用規約", terms_path, class: "font-bold link text-primary whitespace-nowrap" %>
+      <span>と</span>
+      <%= link_to "プライバシーポリシー", privacy_policy_path, class: "font-bold link text-primary whitespace-nowrap" %>
+    </div>
+    <p>© 2026 SokoNote</p>
+  </div>
+</footer>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title><%= content_for(:title) || "Myapp" %></title>
+    <!-- タイトルバーの自動切り替え -->
+    <title><%= content_for(:title) || "SokoNote" %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <%= csrf_meta_tags %>

--- a/app/views/privacy_policy/index.html.erb
+++ b/app/views/privacy_policy/index.html.erb
@@ -1,0 +1,126 @@
+<!-- プライバシーポリシー -->
+<% content_for :arrow_back do %>
+  arrow_back
+<% end %>
+<% content_for :title do %>
+  プライバシーポリシー
+<% end %>
+
+<!-- 白大枠 -->
+<article class="bg-white rounded shadow-sm px-6 py-10 md:px-12 md:py-12 leading-loose">
+
+  <!-- 第1条 -->
+  <section class="mb-10">
+    <h2 class="text-lg font-semibold border-b border-light-gray pb-2 mb-4">
+      <span class="text-primary mr-3">1.</span>お客様から取得する情報
+    </h2>
+    <p class="mb-3 text-dark-gray">当方は、お客様から以下の情報を取得します。</p>
+    <ul class="list-disc pl-6 space-y-2 text-dark-gray marker:text-primary">
+      <li>氏名（ニックネームやペンネームを含む）</li>
+      <li>メールアドレス</li>
+      <li>外部サービスでお客様が利用するIDおよび、外部サービスのプライバシー設定によりお客様が開示を認めた情報</li>
+      <li>LINE株式会社が提供する「LINEログイン」を利用した場合に取得するユーザー識別子（ユーザーID）</li>
+      <li>利用者が本サービス上に入力・保存する文章その他のデータ（以下「記録内容」）</li>
+      <li>Cookieその他の類似技術により取得される識別情報</li>
+      <li>OSが生成するID、端末の種類、端末識別子など、お客様が利用するOSや端末に関する情報</li>
+    </ul>
+  </section>
+
+  <!-- 第2条 -->
+  <section class="mb-10">
+    <h2 class="text-lg font-semibold border-b border-light-gray pb-2 mb-4">
+      <span class="text-primary mr-3">2.</span>お客様の情報を利用する目的
+    </h2>
+    <p class="mb-3 text-dark-gray">当方は、お客様から取得した情報を以下の目的で利用します。</p>
+    <ol class="list-decimal pl-6 space-y-2 text-dark-gray marker:text-primary">
+      <li>サービス登録手続の受付、本人確認および認証処理のため</li>
+      <li>当方におけるお客様の利用履歴の管理のため</li>
+      <li>当方の利便性向上や機能改善に役立てるため</li>
+      <li>当方に関するご案内のため</li>
+      <li>お客様からのお問い合わせへの対応のため</li>
+      <li>当方の規約や法令に違反する行為に対する対応のため</li>
+      <li>当方に関する重要なお知らせや契約上必要な連絡を行うため</li>
+      <li>その他、当方の提供、維持、保護および改善のため</li>
+    </ol>
+  </section>
+
+  <!-- 第3条 -->
+  <section class="mb-10">
+    <h2 class="text-lg font-semibold border-b border-light-gray pb-2 mb-4">
+      <span class="text-primary mr-3">3.</span>安全管理のために講じた措置
+    </h2>
+    <p class="text-dark-gray">当方は、お客様の情報を保護するため、通信の暗号化（SSL）など、適切な安全管理措置を講じています。詳細については、法令に基づき合理的な範囲で個別にご案内いたします。</p>
+  </section>
+
+  <!-- 第4条 -->
+  <section class="mb-10">
+    <h2 class="text-lg font-semibold border-b border-light-gray pb-2 mb-4">
+      <span class="text-primary mr-3">4.</span>第三者提供
+    </h2>
+    <p class="mb-3 text-dark-gray">当方は、お客様の個人データ（個人情報保護法第16条第3項）を、以下の場合を除き、あらかじめお客様の同意を得ることなく第三者（日本国外の者を含む）に提供することはありません。</p>
+    <ul class="list-disc pl-6 space-y-2 text-dark-gray marker:text-primary">
+      <li>個人データの取扱いを外部に委託する場合</li>
+      <li>当方が買収された場合</li>
+      <li>法令により第三者提供が認められている場合</li>
+    </ul>
+  </section>
+
+  <!-- 第5条 -->
+  <section class="mb-10">
+    <h2 class="text-lg font-semibold border-b border-light-gray pb-2 mb-4">
+      <span class="text-primary mr-3">5.</span>アクセス解析ツールの利用
+    </h2>
+    <p class="mb-3 text-dark-gray">当方は、アクセス解析のために「Googleアナリティクス」を利用しています。GoogleアナリティクスはCookieを使用し、匿名のトラフィックデータを収集します。個人を特定するものではありません。</p>
+    <p class="mb-3 text-dark-gray">Cookieを無効にすることで、情報の収集を拒否することが可能です。詳しくは、お使いのブラウザの設定をご確認ください。</p>
+    <p class="text-dark-gray">
+      Googleアナリティクスの詳細については、以下をご参照ください：<br>
+      <a href="https://marketingplatform.google.com/about/analytics/terms/jp/"
+         target="_blank"
+         rel="noopener noreferrer"
+         class="text-primary underline break-all hover:opacity-75 transition-opacity">
+        https://marketingplatform.google.com/about/analytics/terms/jp/
+      </a>
+    </p>
+  </section>
+
+  <!-- 第6条 -->
+  <section class="mb-10">
+    <h2 class="text-lg font-semibold border-b border-light-gray pb-2 mb-4">
+      <span class="text-primary mr-3">6.</span>プライバシーポリシーの変更
+    </h2>
+    <p class="mb-3 text-dark-gray">本ポリシーの内容は、法令その他本ポリシーに別段の定めのある事項を除いて、ユーザーに通知することなく、変更することができるものとします。</p>
+    <p class="text-dark-gray">当方が別途定める場合を除いて、変更後のプライバシーポリシーは、本ウェブサイトに掲載したときから効力を生じるものとします。</p>
+  </section>
+
+  <!-- 第7条 -->
+  <section class="mb-10">
+    <h2 class="text-lg font-semibold border-b border-light-gray pb-2 mb-4">
+      <span class="text-primary mr-3">7.</span>お問い合わせ
+    </h2>
+    <p class="mb-3 text-dark-gray">お客様の情報の開示、訂正、利用停止、削除をご希望される場合は、お問い合わせフォームよりご連絡ください。</p>
+    <p class="text-dark-gray">ご本人確認のため、運転免許証等の提示をお願いする場合があります。なお、開示請求については、開示の有無にかかわらず、1件あたり1,000円（税込）の事務手数料を申し受けます。</p>
+  </section>
+
+  <!-- 事業者情報 -->
+  <section class="mt-12 pt-6 border-t border-light-gray">
+    <dl class="text-sm text-dark-gray space-y-1">
+      <div class="flex">
+        <dt class="w-28 shrink-0 text-middle-gray">制定日</dt>
+        <dd>2026年5月3日</dd>
+      </div>
+      <div class="flex">
+        <dt class="w-28 shrink-0 text-middle-gray">事業者名</dt>
+        <dd>SokoNote運営者</dd>
+      </div>
+      <div class="flex">
+        <dt class="w-28 shrink-0 text-middle-gray">連絡先</dt>
+        <dd>お問い合わせフォームよりご連絡ください</dd>
+      </div>
+    </dl>
+  </section>
+
+  <footer class="mt-8 pt-6 border-t border-light-gray text-right text-middle-gray">
+    以上
+  </footer>
+
+</article>

--- a/app/views/setting/index.html.erb
+++ b/app/views/setting/index.html.erb
@@ -61,7 +61,7 @@
     <p class="font-bold text-primary mb-2 px-1">サポート &amp; 情報</p>
     <div class="bg-white rounded-2xl shadow-sm ring ring-light-gray">
       <!-- 利用規約 -->
-      <%= link_to "#", class: "card shadow-none flex items-center gap-4 p-4 rounded-t-2xl hover:bg-light-gray hover:shadow-lg active:shadow-sm transition" do %>
+      <%= link_to terms_path, class: "card shadow-none flex items-center gap-4 p-4 rounded-t-2xl hover:bg-light-gray hover:shadow-lg active:shadow-sm transition" do %>
         <div class="w-10 h-10 rounded-full bg-primary/20 flex items-center justify-center text-primary">
           <span class="material-symbols-outlined text-xl">description</span>
         </div>
@@ -70,7 +70,7 @@
       <% end %>
       <hr class="border-light-gray">
       <!-- プライバシーポリシー -->
-      <%= link_to "#", class: "card flex items-center gap-4 p-4 rounded-b-2xl hover:bg-light-gray transition" do %>
+      <%= link_to privacy_policy_path, class: "card flex items-center gap-4 p-4 rounded-b-2xl hover:bg-light-gray transition" do %>
         <div class="w-10 h-10 rounded-full bg-primary/20 flex items-center justify-center text-primary">
           <span class="material-symbols-outlined text-xl">privacy_tip</span>
         </div>

--- a/app/views/terms/index.html.erb
+++ b/app/views/terms/index.html.erb
@@ -1,0 +1,226 @@
+<!-- 利用規約 -->
+<% content_for :arrow_back do %>
+  arrow_back
+<% end %>
+<% content_for :title do %>
+  利用規約
+<% end %>
+
+<!-- 白大枠 -->
+<article class="bg-white rounded shadow-sm px-6 py-10 md:px-12 md:py-12 leading-loose">
+
+  <!-- はじめに -->
+  <section class="mb-10">
+    <h2 class="text-lg font-semibold border-b border-light-gray pb-2 mb-4">
+      <span class="text-primary mr-3">はじめに</span>
+    </h2>
+    <p class="mb-3 text-dark-gray">
+      この利用規約（以下、「本規約」といいます。）は、ウェブサイト上で提供するサービス（以下、「本サービス」といいます。）の利用条件を定めるものです。登録ユーザーの皆さま（以下、「ユーザー」といいます。）には、本規約に従って、本サービスをご利用いただきます。
+    </p>
+  </section>
+
+  <!-- 第1条 -->
+  <section class="mb-10">
+    <h2 class="text-lg font-semibold border-b border-light-gray pb-2 mb-4">
+      <span class="text-primary mr-3">第1条</span>適用
+    </h2>
+    <ol class="list-decimal pl-6 space-y-2 text-dark-gray marker:text-primary">
+      <li>本規約は、ユーザーと当方との間の本サービスの利用に関わる一切の関係に適用されるものとします。</li>
+      <li>当方は本サービスに関し、本規約のほか、ご利用にあたってのルール等、各種の定め（以下、「個別規定」といいます。）をすることがあります。これら個別規定はその名称のいかんに関わらず、本規約の一部を構成するものとします。</li>
+      <li>本規約の規定が前項の個別規定の規定と矛盾する場合には、個別規定において特段の定めなき限り、個別規定の規定が優先されるものとします。</li>
+    </ol>
+  </section>
+
+  <!-- 第2条 -->
+  <section class="mb-10">
+    <h2 class="text-lg font-semibold border-b border-light-gray pb-2 mb-4">
+      <span class="text-primary mr-3">第2条</span>利用登録
+    </h2>
+    <ol class="list-decimal pl-6 space-y-2 text-dark-gray marker:text-primary">
+      <li>本サービスにおいては、登録希望者が本規約に同意の上、当方の定める方法によって利用登録を申請し、当方がこれを承認することによって、利用登録が完了するものとします。</li>
+      <li>当方は、利用登録の申請者に以下の事由があると判断した場合、利用登録の申請を承認しないことがあり、その理由については一切の開示義務を負わないものとします。
+        <ul class="list-disc mt-2 pl-4 space-y-1 text-dark-gray">
+          <li> 利用登録の申請に際して虚偽の事項を届け出た場合</li>
+          <li> 本規約に違反したことがある者からの申請である場合</li>
+          <li> その他、当方が利用登録を相当でないと判断した場合</li>
+        </ul>
+      </li>
+    </ol>
+  </section>
+
+  <!-- 第3条 -->
+  <section class="mb-10">
+    <h2 class="text-lg font-semibold border-b border-light-gray pb-2 mb-4">
+      <span class="text-primary mr-3">第3条</span>ユーザーIDおよびパスワードの管理
+    </h2>
+    <ol class="list-decimal pl-6 space-y-2 text-dark-gray marker:text-primary">
+      <li>ユーザーは、自己の責任において、本サービスのユーザーIDおよびパスワードを適切に管理するものとします。</li>
+      <li>ユーザーは、いかなる場合にも、ユーザーIDおよびパスワードを第三者に譲渡または貸与し、もしくは第三者と共用することはできません。当方は、ユーザーIDとパスワードの組み合わせが登録情報と一致してログインされた場合には、そのユーザーIDを登録しているユーザー自身による利用とみなします。</li>
+      <li>ユーザーIDおよびパスワードが第三者によって使用されたことによって生じた損害は、当方に故意又は重大な過失がある場合を除き、当方は一切の責任を負わないものとします。</li>
+    </ol>
+  </section>
+
+  <!-- 第4条 -->
+  <section class="mb-10">
+    <h2 class="text-lg font-semibold border-b border-light-gray pb-2 mb-4">
+      <span class="text-primary mr-3">第4条</span>禁止事項
+    </h2>
+    <p class="mb-3 text-dark-gray">ユーザーは、本サービスの利用にあたり、以下の行為をしてはなりません。</p>
+    <ol class="list-decimal pl-6 space-y-2 text-dark-gray marker:text-primary">
+      <li>法令または公序良俗に違反する行為</li>
+      <li>犯罪行為に関連する行為</li>
+      <li>本サービスの内容等、本サービスに含まれる著作権、商標権ほか知的財産権を侵害する行為</li>
+      <li>当方、ほかのユーザー、またはその他第三者のサーバーまたはネットワークの機能を破壊したり、妨害したりする行為</li>
+      <li>本サービスによって得られた情報を商業的に利用する行為</li>
+      <li>当方のサービスの運営を妨害するおそれのある行為</li>
+      <li>不正アクセスをし、またはこれを試みる行為</li>
+      <li>他のユーザーに関する個人情報等を収集または蓄積する行為</li>
+      <li>不正な目的を持って本サービスを利用する行為</li>
+      <li>本サービスの他のユーザーまたはその他の第三者に不利益、損害、不快感を与える行為</li>
+      <li>他のユーザーに成りすます行為</li>
+      <li>当方が許諾しない本サービス上での宣伝、広告、勧誘、または営業行為</li>
+      <li>当方のサービスに関連して、反社会的勢力に対して直接または間接に利益を供与する行為</li>
+      <li>その他、当方が不適切と判断する行為</li>
+    </ol>
+  </section>
+
+  <!-- 第5条 -->
+  <section class="mb-10">
+    <h2 class="text-lg font-semibold border-b border-light-gray pb-2 mb-4">
+      <span class="text-primary mr-3">第5条</span>本サービスの提供の停止等
+    </h2>
+    <ol class="list-decimal pl-6 space-y-2 text-dark-gray marker:text-primary">
+      <li>当方は、以下のいずれかの事由があると判断した場合、ユーザーに事前に通知することなく本サービスの全部または一部の提供を停止または中断することができるものとします。
+        <ul class="list-disc mt-2 pl-4 space-y-1 text-dark-gray">
+          <li>本サービスにかかるコンピュータシステムの保守点検または更新を行う場合</li>
+          <li>地震、落雷、火災、停電または天災などの不可抗力により、本サービスの提供が困難となった場合</li>
+          <li>コンピュータまたは通信回線等が事故により停止した場合</li>
+          <li>その他、当方が本サービスの提供が困難と判断した場合</li>
+        </ul>
+      </li>
+      <li>当方は、本サービスの提供の停止または中断により、ユーザーまたは第三者が被ったいかなる不利益または損害についても、一切の責任を負わないものとします。</li>
+    </ol>
+  </section>
+
+  <!-- 第6条 -->
+  <section class="mb-10">
+    <h2 class="text-lg font-semibold border-b border-light-gray pb-2 mb-4">
+      <span class="text-primary mr-3">第6条</span>利用制限および登録抹消
+    </h2>
+    <ol class="list-decimal pl-6 space-y-2 text-dark-gray marker:text-primary">
+      <li>当方は、ユーザーが以下のいずれかに該当する場合には、事前の通知なく、ユーザーに対して、本サービスの全部もしくは一部の利用を制限し、またはユーザーとしての登録を抹消することができるものとします。
+        <ul class="list-disc mt-2 pl-4 space-y-1 text-dark-gray">
+          <li>本規約のいずれかの条項に違反した場合</li>
+          <li>登録事項に虚偽の事実があることが判明した場合</li>
+          <li>当方からの連絡に対し、一定期間返答がない場合</li>
+          <li>本サービスについて、最終の利用から一定期間利用がない場合</li>
+          <li>その他、当方が本サービスの利用を適当でないと判断した場合</li>
+        </ul>
+      </li>
+      <li>当方は、本条に基づき当方が行った行為によりユーザーに生じた損害について、一切の責任を負いません。</li>
+    </ol>
+  </section>
+
+  <!-- 第7条 -->
+  <section class="mb-10">
+    <h2 class="text-lg font-semibold border-b border-light-gray pb-2 mb-4">
+      <span class="text-primary mr-3">第7条</span>退会
+    </h2>
+    <ol class="list-decimal pl-6 space-y-2 text-dark-gray marker:text-primary">
+      <li>ユーザーは、当方の定める退会手続により、本サービスから退会できるものとします。</li>
+      <li>ユーザーが退会した場合、当方は当該ユーザーの記録内容その他の登録情報を、合理的な期間内に削除します。ただし、法令に基づき保存が必要な情報は除きます。</li>
+    </ol>
+  </section>
+
+  <!-- 第8条 -->
+  <section class="mb-10">
+    <h2 class="text-lg font-semibold border-b border-light-gray pb-2 mb-4">
+      <span class="text-primary mr-3">第8条</span>保証の否認および免責事項
+    </h2>
+    <ol class="list-decimal pl-6 space-y-2 text-dark-gray marker:text-primary">
+      <li>当方は、本サービスに事実上または法律上の瑕疵（安全性、信頼性、正確性、完全性、有効性、特定の目的への適合性、セキュリティなどに関する欠陥、エラーやバグ、権利侵害などを含みます。）がないことを明示的にも黙示的にも保証しておりません。</li>
+      <li>本サービスにおいて提供される価格情報、商品情報等は、ユーザーの入力または第三者の情報に基づくものであり、その正確性、完全性、有用性等について当方は一切保証するものではありません。</li>
+      <li>ユーザーは、本サービスの情報を自己の判断と責任において利用するものとし、これにより生じた損害について当方は一切の責任を負いません。</li>
+      <li>当方は、本サービスに起因してユーザーに生じたあらゆる損害について、当方の故意又は重大な過失による場合を除き、一切の責任を負いません。ただし、本サービスに関する当方とユーザーとの間の契約（本規約を含みます。）が消費者契約法に定める消費者契約となる場合、この免責規定は適用されません。</li>
+      <li>前項ただし書に定める場合であっても、当方は、当方の過失（重大な過失を除きます。）による債務不履行または不法行為によりユーザーに生じた損害のうち、特別な事情から生じた損害については一切の責任を負いません。また、当方の過失（重大な過失を除きます。）による損害賠償の範囲は、直接かつ通常の損害に限られるものとします。</li>
+      <li>当方は、ユーザーのデータの消失、破損、改ざん等について一切の責任を負いません。</li>
+      <li>当方は、本サービスに関して、ユーザーと他のユーザーまたは第三者との間において生じた取引、連絡または紛争等について一切責任を負いません。</li>
+    </ol>
+  </section>
+
+  <!-- 第9条 -->
+  <section class="mb-10">
+    <h2 class="text-lg font-semibold border-b border-light-gray pb-2 mb-4">
+      <span class="text-primary mr-3">第9条</span>広告表示
+    </h2>
+    <ol class="list-decimal pl-6 space-y-2 text-dark-gray marker:text-primary">
+      <li>本サービスには、当方または第三者の広告が表示される場合があります。</li>
+      <li>当方は、本サービス上の広告の表示場所、表示内容、表示方法等を、ユーザーへの事前の通知なく変更することができるものとします。</li>
+      <li>広告の配信にあたり、第三者配信事業者がCookie等を使用してユーザーの情報を収集する場合があります。詳細は当方のプライバシーポリシーをご確認ください。</li>
+    </ol>
+  </section>
+
+  <!-- 第10条 -->
+  <section class="mb-10">
+    <h2 class="text-lg font-semibold border-b border-light-gray pb-2 mb-4">
+      <span class="text-primary mr-3">第10条</span>サービス内容の変更等
+    </h2>
+    <p class="text-dark-gray">当方は、ユーザーへの事前の告知をもって、本サービスの内容を変更、追加または廃止することがあり、ユーザーはこれを承諾するものとします。</p>
+  </section>
+
+  <!-- 第11条 -->
+  <section class="mb-10">
+    <h2 class="text-lg font-semibold border-b border-light-gray pb-2 mb-4">
+      <span class="text-primary mr-3">第11条</span>利用規約の変更
+    </h2>
+    <ol class="list-decimal pl-6 space-y-2 text-dark-gray marker:text-primary">
+      <li>当方は以下の場合には、ユーザーの個別の同意を要せず、本規約を変更することができるものとします。
+        <ul class="list-disc mt-2 pl-4 space-y-1 text-dark-gray">
+          <li>本規約の変更がユーザーの一般の利益に適合するとき</li>
+          <li>本規約の変更が本サービス利用契約の目的に反せず、かつ、変更の必要性、変更後の内容の相当性その他の変更に係る事情に照らして合理的なものであるとき</li>
+        </ul>
+      </li>
+      <li>当方はユーザーに対し、前項による本規約の変更にあたり、事前に、本規約を変更する旨及び変更後の本規約の内容並びにその効力発生時期を通知します。</li>
+    </ol>
+  </section>
+
+  <!-- 第12条 -->
+  <section class="mb-10">
+    <h2 class="text-lg font-semibold border-b border-light-gray pb-2 mb-4">
+      <span class="text-primary mr-3">第12条</span>個人情報の取扱い
+    </h2>
+    <p class="text-dark-gray">当方は、本サービスの利用によって取得する個人情報については、当方「プライバシーポリシー」に従い適切に取り扱うものとします。</p>
+  </section>
+
+  <!-- 第13条 -->
+  <section class="mb-10">
+    <h2 class="text-lg font-semibold border-b border-light-gray pb-2 mb-4">
+      <span class="text-primary mr-3">第13条</span>通知または連絡
+    </h2>
+    <p class="text-dark-gray">ユーザーと当方との間の通知または連絡は、当方の定める方法によって行うものとします。当方は、ユーザーから、当方が別途定める方式に従った変更届け出がない限り、現在登録されている連絡先が有効なものとみなして当該連絡先へ通知または連絡を行い、これらは、発信時にユーザーへ到達したものとみなします。</p>
+  </section>
+
+  <!-- 第14条 -->
+  <section class="mb-10">
+    <h2 class="text-lg font-semibold border-b border-light-gray pb-2 mb-4">
+      <span class="text-primary mr-3">第14条</span>権利義務の譲渡の禁止
+    </h2>
+    <p class="text-dark-gray">ユーザーは、当方の書面による事前の承諾なく、利用契約上の地位または本規約に基づく権利もしくは義務を第三者に譲渡し、または担保に供することはできません。</p>
+  </section>
+
+  <!-- 第15条 -->
+  <section class="mb-10">
+    <h2 class="text-lg font-semibold border-b border-light-gray pb-2 mb-4">
+      <span class="text-primary mr-3">第15条</span>準拠法・裁判管轄
+    </h2>
+    <ol class="list-decimal pl-6 space-y-2 text-dark-gray marker:text-primary">
+      <li>本規約の解釈にあたっては、日本法を準拠法とします。</li>
+      <li>本サービスに関して紛争が生じた場合には、当方の所在地を管轄する裁判所を専属的合意管轄とします。</li>
+    </ol>
+  </section>
+
+  <footer class="mt-12 pt-6 border-t border-light-gray text-right text-dark-gray">
+    以上
+  </footer>
+
+</article>

--- a/app/views/users/passwords/edit.html.erb
+++ b/app/views/users/passwords/edit.html.erb
@@ -1,6 +1,11 @@
 <!-- パスワードリセット画面 -->
-<div class="flex flex-col md:flex-row items-center justify-center gap-6 p-4">
-  <div class="bg-white rounded-3xl shadow-xl w-full px-7 py-8">
+<!-- ヘッダー配色の変更 -->
+<% content_for :header_class do %>
+  bg-primary text-white
+<% end %>
+
+<div class="flex flex-col md:flex-row items-center justify-center gap-6">
+  <div class="bg-white rounded-2xl border border-light-gray w-full p-4">
     <h2 class="text-center text-2xl font-bold text-black mb-6"><%= t("devise.passwords.edit.change_your_password") %></h2>
     <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
       <%= render "users/shared/error_messages", resource: resource %>
@@ -21,7 +26,7 @@
         </div>
       </div>
 
-      <div class="mb-5">
+      <div class="mb-10">
         <%= f.label :password_confirmation, class: "block text-black font-semibold mb-2" %>
         <div class="flex items-center border border-light-gray rounded-xl px-3 py-3 bg-white focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition">
           <span class="material-symbols-outlined text-middle-gray mr-2" style="font-size: 20px;">lock</span>
@@ -29,14 +34,18 @@
         </div>
       </div>
 
-      <div class="mb-5">
-        <%= f.button :submit, class: "w-full bg-primary cursor-pointer hover:bg-[#5aad2e] active:bg-[#4d9a26] text-white font-bold text-lg rounded-2xl py-4 flex items-center justify-center gap-2 shadow-md transition duration-150" do %>
+      <div class="mb-10 px-2">
+        <%= f.button :submit, class: "card w-full bg-primary text-white px-6 py-4 rounded-full flex items-center justify-center font-bold text-xl tracking-widest", data: { controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" } do %>
           <%= t("devise.passwords.edit.change_my_password") %>
-          <span class="material-symbols-outlined" style="font-size: 22px;">lock_reset</span>
+          <span class="material-symbols-outlined">lock_reset</span>
         <% end %>
       </div>
     <% end %>
   </div>
 </div>
 
-<%= render "users/shared/links" %>
+<!-- ログイン画面移行動線 -->
+<div class="mt-4 text-center">
+  <%= link_to "ログイン画面に戻る", new_session_path(resource_name), class: "block mt-6 font-bold link text-primary whitespace-nowrap" %>
+</div>
+

--- a/app/views/users/passwords/new.html.erb
+++ b/app/views/users/passwords/new.html.erb
@@ -1,17 +1,21 @@
 <!-- パスワードリセット時のメール送信画面 -->
+<!-- ヘッダー配色の変更 -->
+<% content_for :header_class do %>
+  bg-primary text-white
+<% end %>
 <% content_for :arrow_back do %>
   arrow_back
 <% end %>
-<div class="flex flex-col md:flex-row items-center justify-center gap-6 p-4">
-  <div class="bg-white rounded-3xl shadow-xl w-full px-7 py-8">
+<div class="flex flex-col md:flex-row items-center justify-center gap-6">
+  <div class="bg-white rounded-2xl border border-light-gray w-full p-4">
     <h2 class="text-center text-2xl font-bold text-black mb-6"><%= t("devise.passwords.new.forgot_your_password") %></h2>
 
     <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
       <%= render "users/shared/error_messages", resource: resource %>
 
-      <div class="mb-5">
+      <div class="mb-10">
         <%= f.label :email, class: "block text-black font-semibold mb-2"%>
-        <div class="flex items-center border border-ligth-gray rounded-xl px-3 py-3 bg-white focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition">
+        <div class="flex items-center border border-light-gray rounded-xl px-3 py-3 bg-white focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition">
           <span class="material-symbols-outlined text-middle-gray mr-2" style="font-size: 20px;">
             mail
           </span>
@@ -19,14 +23,16 @@
         </div>
       </div>
 
-      <div class="mb-5">
-        <%= f.button :submit, class: "w-full bg-primary cursor-pointer hover:bg-[#5aad2e] active:bg-[#4d9a26] text-white font-bold text-lg rounded-2xl py-4 flex items-center justify-center gap-2 shadow-md transition duration-150" do %>
+      <div class="mb-10 px-2">
+        <%= f.button :submit, class: "card w-full bg-primary text-white px-6 py-4 rounded-full flex items-center justify-center font-bold text-xl tracking-widest", data: { controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" } do %>
           <%= t("devise.passwords.new.send_me_reset_password_instructions") %>
         <% end %>
       </div>
     <% end %>
   </div>
 </div>
-<div class="mt-4 text-center text-dark-gray space-y-2">
-  <%= render "users/shared/links" %>
+
+<!-- ログイン画面移行動線 -->
+<div class="mt-4 text-center">
+  <%= link_to "ログイン画面に戻る", new_session_path(resource_name), class: "block mt-6 font-bold link text-primary whitespace-nowrap" %>
 </div>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -1,10 +1,14 @@
 <!-- アカウント登録画面 -->
+<!-- ヘッダー配色の変更 -->
+<% content_for :header_class do %>
+  bg-primary text-white
+<% end %>
 <% content_for :arrow_back do %>
   arrow_back
 <% end %>
-<div class="flex flex-col md:flex-row items-center justify-center gap-6 p-4">
-  <div class="bg-white rounded-3xl shadow-xl w-full px-7 py-8">
-    <h2 class="text-center text-2xl font-bold text-black mb-6"><%= t("devise.registrations.new.sign_up") %></h2>
+<div class="flex flex-col md:flex-row items-center justify-center gap-6">
+  <div class="bg-white rounded-2xl border border-light-gray w-full p-4">
+    <h2 class="text-center text-2xl font-bold text-black my-6"><%= t("devise.registrations.new.sign_up") %></h2>
 
     <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
       <%= render "users/shared/error_messages", resource: resource %>
@@ -15,7 +19,7 @@
           <span class="material-symbols-outlined text-middle-gray mr-2" style="font-size: 20px;">
             account_circle
           </span>
-          <%= f.text_field :name, placeholder: "お名前", class: "flex-1 outline-none text-black bg-transparent placeholder-gray-400"%>
+          <%= f.text_field :name, autofocus: true, placeholder: "お名前", class: "flex-1 outline-none text-black bg-transparent placeholder-gray-400"%>
         </div>
       </div>
 
@@ -25,7 +29,7 @@
           <span class="material-symbols-outlined text-middle-gray mr-2" style="font-size: 20px;">
             mail
           </span>
-          <%= f.email_field :email, autofocus: true, placeholder: "example@email.com", class: "flex-1 outline-none text-black bg-transparent placeholder-gray-400" %>
+          <%= f.email_field :email, placeholder: "example@email.com", class: "flex-1 outline-none text-black bg-transparent placeholder-gray-400" %>
         </div>
       </div>
 
@@ -44,7 +48,7 @@
         </div>
       </div>
 
-      <div class="mb-5">
+      <div class="mb-10">
         <%= f.label :password_confirmation, class: "block text-black font-semibold mb-2" %>
         <div class="flex items-center border border-light-gray rounded-xl px-3 py-3 bg-white focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition">
           <span class="material-symbols-outlined text-middle-gray mr-2" style="font-size: 20px;">lock</span>
@@ -52,16 +56,38 @@
         </div>
       </div>
 
+      <!-- 利用規約・プライバシーポリシー同意チェック -->
+      <div class="flex justify-center mb-10">
+        <label class="flex items-center gap-2">
+          <%= check_box_tag :agreement, nil, nil, required: true, class: "w-5 h-5 accent-primary text-center" %>
+          <span class="text-black">
+            <%= link_to "利用規約", terms_path, class: "font-bold link text-primary whitespace-nowrap" %> と
+            <%= link_to "プライバシーポリシー", privacy_policy_path, class: "font-bold link text-primary whitespace-nowrap" %>
+            に同意します
+          </span>
+        </label>
+      </div>
+
       <div class="mb-5">
-        <%= f.button :submit, class: "w-full bg-primary cursor-pointer hover:bg-[#5aad2e] active:bg-[#4d9a26] text-white font-bold text-lg rounded-2xl py-4 flex items-center justify-center gap-2 shadow-md transition duration-150" do %>
+        <%= f.button :submit, class: "card w-full bg-primary text-white px-6 py-4 rounded-full flex items-center justify-center font-bold text-xl tracking-widest", data: { controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" } do %>
           <%= t("devise.registrations.new.sign_up") %>
-          <span class="material-symbols-outlined" style="font-size: 22px;">login</span>
+          <span class="material-symbols-outlined">login</span>
         <% end %>
       </div>
     <% end %>
+    <div class="flex items-center gap-4 my-5 mx-2">
+      <hr class="flex-1 border-dark-gray">
+      <span class="text-dark-gray">または</span>
+      <hr class="flex-1 border-dark-gray">
+    </div>
+
+    <!-- LINE新規登録動線 -->
+    <%= render "users/shared/omniauth_links" %>
   </div>
 </div>
-<div class="mt-4 text-center text-sm text-gray-500 space-y-2">
+
+<!-- ログイン画面移行動線 -->
+<div class="mt-4 text-center">
   <%= render "users/shared/links" %>
 </div>
 

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -59,7 +59,7 @@
       <!-- 利用規約・プライバシーポリシー同意チェック -->
       <div class="flex justify-center mb-10">
         <label class="flex items-center gap-2">
-          <%= check_box_tag :agreement, nil, nil, required: true, class: "w-5 h-5 accent-primary text-center" %>
+          <%= check_box_tag :agreement, nil, nil, required: true, class: "w-5 h-5 accent-primary text-center cursor-pointer" %>
           <span class="text-black">
             <%= link_to "利用規約", terms_path, class: "font-bold link text-primary whitespace-nowrap" %> と
             <%= link_to "プライバシーポリシー", privacy_policy_path, class: "font-bold link text-primary whitespace-nowrap" %>
@@ -68,7 +68,7 @@
         </label>
       </div>
 
-      <div class="mb-5">
+      <div class="mb-5 px-2">
         <%= f.button :submit, class: "card w-full bg-primary text-white px-6 py-4 rounded-full flex items-center justify-center font-bold text-xl tracking-widest", data: { controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" } do %>
           <%= t("devise.registrations.new.sign_up") %>
           <span class="material-symbols-outlined">login</span>
@@ -82,7 +82,9 @@
     </div>
 
     <!-- LINE新規登録動線 -->
-    <%= render "users/shared/omniauth_links" %>
+    <div class="px-2">
+      <%= render "users/shared/omniauth_links" %>
+    </div>
   </div>
 </div>
 

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -61,8 +61,8 @@
         <label class="flex items-center gap-2">
           <%= check_box_tag :agreement, nil, nil, required: true, class: "w-5 h-5 accent-primary text-center cursor-pointer" %>
           <span class="text-black">
-            <%= link_to "利用規約", terms_path, class: "font-bold link text-primary whitespace-nowrap" %> と
-            <%= link_to "プライバシーポリシー", privacy_policy_path, class: "font-bold link text-primary whitespace-nowrap" %>
+            <%= link_to "利用規約", terms_path, class: "font-bold link text-primary whitespace-nowrap, target: "_blank", rel: "noopener noreferrer" %> と
+            <%= link_to "プライバシーポリシー", privacy_policy_path, class: "font-bold link text-primary whitespace-nowrap, target: "_blank", rel: "noopener noreferrer" %>
             に同意します
           </span>
         </label>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -61,8 +61,8 @@
         <label class="flex items-center gap-2">
           <%= check_box_tag :agreement, nil, nil, required: true, class: "w-5 h-5 accent-primary text-center cursor-pointer" %>
           <span class="text-black">
-            <%= link_to "利用規約", terms_path, class: "font-bold link text-primary whitespace-nowrap, target: "_blank", rel: "noopener noreferrer" %> と
-            <%= link_to "プライバシーポリシー", privacy_policy_path, class: "font-bold link text-primary whitespace-nowrap, target: "_blank", rel: "noopener noreferrer" %>
+            <%= link_to "利用規約", terms_path, class: "font-bold link text-primary whitespace-nowrap", target: "_blank", rel: "noopener noreferrer" %> と
+            <%= link_to "プライバシーポリシー", privacy_policy_path, class: "font-bold link text-primary whitespace-nowrap", target: "_blank", rel: "noopener noreferrer" %>
             に同意します
           </span>
         </label>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,10 +1,14 @@
 <!-- ログイン画面 -->
+<!-- ヘッダー配色の変更 -->
+<% content_for :header_class do %>
+  bg-primary text-white
+<% end %>
 <% content_for :arrow_back do %>
   arrow_back
 <% end %>
-<div class="flex flex-col md:flex-row items-center justify-center gap-6 p-4"> 
-  <div class="bg-white rounded-3xl shadow-xl w-full px-7 py-8">
-    <h2 class="text-center text-2xl font-bold text-black mb-6"><%= t("devise.sessions.new.sign_in") %></h2>
+<div class="flex flex-col md:flex-row items-center justify-center gap-6"> 
+  <div class="bg-white rounded-2xl border border-light-gray w-full p-4">
+    <h2 class="text-center text-2xl font-bold text-black my-6"><%= t("devise.sessions.new.sign_in") %></h2>
 
     <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
       <div class="mb-5">
@@ -17,7 +21,7 @@
         </div>
       </div>
 
-      <div class="mb-5">
+      <div class="mb-10">
         <%= f.label :password, class: "block text-black font-semibold mb-2" %>
         <div class="flex items-center border border-light-gray rounded-xl px-3 py-3 bg-white focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition">
           <span class="material-symbols-outlined text-middle-gray mr-2" style="font-size: 20px;">lock</span>
@@ -25,22 +29,37 @@
         </div>
       </div>
 
-      <% if devise_mapping.rememberable? %>
-        <label class="flex items-center gap-2 text-dark-gray cursor-pointer select-none mb-6">
-          <%= f.check_box :remember_me,
-              class: "w-4 h-4 rounded border-dark-gray accent-primary cursor-pointer" %>
-          <span>ログインを記憶する</span>
-        </label>
-      <% end %>
-      <div class="mb-5">
-        <%= f.button :submit, class: "btn flex items-center justify-center w-full bg-primary font-bold text-white text-lg rounded-2xl py-4" do %>
+      <!-- 次回自動ログインチェック -->
+      <div class="flex justify-center mb-10">
+        <% if devise_mapping.rememberable? %>
+          <label class="flex items-center gap-2">
+            <%= f.check_box :remember_me, class: "w-5 h-5 accent-primary text-center cursor-pointer" %>
+            <span class="text-black">次回から自動的にログイン</span>
+          </label>
+        <% end %>
+      </div>
+      
+      <div class="mb-5 px-2">
+        <%= f.button :submit, class: "card w-full bg-primary text-white px-6 py-4 rounded-full flex items-center justify-center font-bold text-xl tracking-widest", data: { controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" } do %>
           <%= t("devise.sessions.new.sign_in") %>
-          <span class="material-symbols-outlined" style="font-size: 22px;">login</span>
+          <span class="material-symbols-outlined">login</span>
         <% end %>
       </div>
     <% end %>
+    <div class="flex items-center gap-4 my-5 mx-2">
+      <hr class="flex-1 border-dark-gray">
+      <span class="text-dark-gray">または</span>
+      <hr class="flex-1 border-dark-gray">
+    </div>
+
+    <!-- LINEログイン動線 -->
+    <div class="px-2">
+      <%= render "users/shared/omniauth_links" %>
+    </div>
   </div>
 </div>
-<div class="mt-4 text-center text-sm text-dark-gray space-y-2">
+
+<!-- 新規登録画面・パスワードリセット 動線  -->
+<div class="mt-4 text-center space-y-2">
   <%= render "users/shared/links" %>
 </div>

--- a/app/views/users/shared/_links.html.erb
+++ b/app/views/users/shared/_links.html.erb
@@ -1,15 +1,16 @@
-<!-- ログイン画面移行動線 -->
+<!-- ログイン画面動線 -->
 <%- if controller_name != 'sessions' %>
   <%= link_to t("devise.shared.links.log_in"), new_session_path(resource_name), class: "block mt-6 font-bold link text-primary whitespace-nowrap" %>
 <% end %>
 
+<!-- 新規アカウント作成画面動線 -->
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to t("devise.shared.links.sign_up"), new_registration_path(resource_name), class: "block mt-6 text-center text-sm text-gray-500 underline" %>
+  <%= link_to t("devise.shared.links.sign_up"), new_registration_path(resource_name), class: "block mt-6 font-bold link text-primary whitespace-nowrap" %>
 <% end %>
 
-<%# --- パスワードリセット --- %>
+<!-- パスワードリセット画面動線 -->
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to t("devise.shared.links.forgot_your_password"), new_user_password_path, class: "block mt-6 text-center text-sm text-gray-500 underline" %> <!-- パス new_password_path(resource_name) -->
+  <%= link_to t("devise.shared.links.forgot_your_password"), new_user_password_path, class: "block mt-6 font-bold link text-primary whitespace-nowrap" %>
 <% end %>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>

--- a/app/views/users/shared/_links.html.erb
+++ b/app/views/users/shared/_links.html.erb
@@ -1,5 +1,6 @@
+<!-- ログイン画面移行動線 -->
 <%- if controller_name != 'sessions' %>
-  <%= link_to t("devise.shared.links.log_in"), new_session_path(resource_name), class: "block mt-6 text-center text-sm text-gray-500 underline" %>
+  <%= link_to t("devise.shared.links.log_in"), new_session_path(resource_name), class: "block mt-6 font-bold link text-primary whitespace-nowrap" %>
 <% end %>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
@@ -17,16 +18,4 @@
 
 <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
   <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %><br />
-<% end %>
-
-<%# LINEログイン用遷移（POST送信のため、button_toで実装 %> 
-<%- if devise_mapping.omniauthable? %>
-  <%- resource_class.omniauth_providers.each do |provider| %>
-    <%= button_to omniauth_authorize_path(resource_name, provider), method: :post, data: { turbo: false }, class: "btn relative flex items-center mx-auto w-10/12 rounded-2xl overflow-hidden bg-[#06C755]" do %>
-      <div class="flex items-center justify-center w-14 h-14 border-r border-black/[0.08]">
-        <%= image_tag "btn_base.png", class: "w-10 h-10" %>
-      </div>
-      <span class="flex-1 text-center text-white font-bold text-base tracking-wider">LINEでログイン</span>
-    <% end %>
-  <% end %>
 <% end %>

--- a/app/views/users/shared/_omniauth_links.html.erb
+++ b/app/views/users/shared/_omniauth_links.html.erb
@@ -1,0 +1,13 @@
+<!-- LINEログイン用遷移（POST送信のため、button_toで実装 --> 
+<%- if devise_mapping.omniauthable? %>
+  <%- resource_class.omniauth_providers.each do |provider| %>
+    <%= button_to omniauth_authorize_path(resource_name, provider), method: :post, data: { turbo: false, controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" }, class: "card w-full bg-[#06C755] rounded-full relative flex items-center my-5 py-4 px-6" do %>
+      <div class="absolute left-0 top-0 flex items-center justify-center w-14 h-14 border-r border-black/[0.08]">
+        <%= image_tag "btn_base.png", class: "w-10 h-10" %>
+      </div>
+      <span class="flex-1 text-white text-xl font-bold tracking-widest">
+        <%= controller_name == "registrations" ? "LINEで新規登録" : "LINEでログイン" %>
+      </span>
+    <% end %>
+  <% end %>
+<% end %>

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -110,7 +110,7 @@ ja:
         update: 更新
         we_need_your_current_password_to_confirm_your_changes: 変更を反映するには現在のパスワードを入力してください
       new:
-        sign_up: アカウント登録
+        sign_up: 新規アカウント登録
       signed_up: アカウント登録が完了しました。
       signed_up_but_inactive: ログインするためには、アカウントを有効化してください。
       signed_up_but_locked: アカウントがロックされているためログインできません。
@@ -133,7 +133,7 @@ ja:
         sign_in: ログイン
         sign_in_with_provider: "%{provider}でログイン"
         sign_up: アカウントをお持ちでない方はこちら
-        log_in: ログイン画面に移動する #追加
+        log_in: アカウントをお持ちの方はこちら #追加
         omniauth_sign_in: LINEでログイン
       minimum_password_length:
         other: "（%{count}字以上）"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,12 @@ Rails.application.routes.draw do
   # 設定画面
   get "setting", to: "setting#index"
 
+  # 利用規約画面
+  get "terms", to: "terms#index"
+
+  # プライバシーポリシー
+  get "privacy_policy", to: "privacy_policy#index"
+
   # letter_opener_web のルーティング
   mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
 

--- a/spec/helpers/privacy_policy_helper_spec.rb
+++ b/spec/helpers/privacy_policy_helper_spec.rb
@@ -1,0 +1,15 @@
+# require 'rails_helper'
+
+# # Specs in this file have access to a helper object that includes
+# # the PrivacyPolicyHelper. For example:
+# #
+# # describe PrivacyPolicyHelper do
+# #   describe "string concat" do
+# #     it "concats two strings with spaces" do
+# #       expect(helper.concat_strings("this","that")).to eq("this that")
+# #     end
+# #   end
+# # end
+# RSpec.describe PrivacyPolicyHelper, type: :helper do
+#   pending "add some examples to (or delete) #{__FILE__}"
+# end

--- a/spec/helpers/terms_helper_spec.rb
+++ b/spec/helpers/terms_helper_spec.rb
@@ -1,0 +1,15 @@
+# require 'rails_helper'
+
+# # Specs in this file have access to a helper object that includes
+# # the TermsHelper. For example:
+# #
+# # describe TermsHelper do
+# #   describe "string concat" do
+# #     it "concats two strings with spaces" do
+# #       expect(helper.concat_strings("this","that")).to eq("this that")
+# #     end
+# #   end
+# # end
+# RSpec.describe TermsHelper, type: :helper do
+#   pending "add some examples to (or delete) #{__FILE__}"
+# end

--- a/spec/requests/privacy_policy_spec.rb
+++ b/spec/requests/privacy_policy_spec.rb
@@ -1,0 +1,7 @@
+# require 'rails_helper'
+
+# RSpec.describe "PrivacyPolicies", type: :request do
+#   describe "GET /index" do
+#     pending "add some examples (or delete) #{__FILE__}"
+#   end
+# end

--- a/spec/requests/terms_spec.rb
+++ b/spec/requests/terms_spec.rb
@@ -1,0 +1,7 @@
+# require 'rails_helper'
+
+# RSpec.describe "Terms", type: :request do
+#   describe "GET /index" do
+#     pending "add some examples (or delete) #{__FILE__}"
+#   end
+# end


### PR DESCRIPTION
### 関連ISSUE
---
close #169 

### 変更内容
---
- 利用規約を閲覧できるよう実装しました。
- プライバシーポリシーを閲覧できる実装しました。
- 上記2つについて、未ログイン時にも閲覧できるよう実装しました。
- 新規登録時、上記2つを確認したのちチェックする同意ボタンを実装。
- 未ログイントップページフッターに上記2つのリンクを実装。 

### 動作確認
---
- 未ログインにて
  - 新規登録画面で利用規約とプライバシーポリシーを閲覧できる
  - チェックボックスをonにしないと新規登録できないように設定
  - トップページフッターにて 利用規約とプライバシーポリシーのリンクと著作権マークを確認
- ログイン後にて
  - 設定画面より、利用規約とプライバシーポリシーを閲覧できる  

### 補足・レビュアーへのメモ
---
新規登録画面修正にともない、ユーザー認証周り（ログイン・パスワードリセット・パスワードリセットメール送信も同様にフロントを微調整しました。）

トップ画面において、タイトルバーの名前をSokoNoteに変更しました。