### PR TITLE
feat: ログイン後、userモデル編集を実装

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -57,10 +57,10 @@ class Users::RegistrationsController < Devise::RegistrationsController
   #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
   # end
 
-  # The path used after sign up.
-  # def after_sign_up_path_for(resource)
-  #   super(resource)
-  # end
+  # アカウント情報更新後のリダイレクトURLの設定
+  def after_update_path_for(resource)
+    setting_path(resource)
+  end
 
   # The path used after sign up for inactive accounts.
   # def after_inactive_sign_up_path_for(resource)
@@ -68,6 +68,21 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # end
 
   private
+
+  # メールアドレス変更不可に伴い、更新時のメールアドレス受け入れ不可
+  def account_update_params
+    params.require(:user).permit(:name, :password, :password_confirmation, :current_password)
+  end
+
+  # 変更時、パスワード欄が空でもcurrent_password不要で更新できる
+  def update_resource(resource, params)
+    if params[:password].blank? && params[:password_confirmation].blank?
+      params.delete(:current_password)
+      resource.update_without_password(params.except(:current_password))
+    else
+      resource.update_with_password(params)
+    end
+  end
 
   # devise認証のnameカラムを許可（他のカラムはデフォルトで許可されている）
   def configure_sign_up_params

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -59,7 +59,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   # アカウント情報更新後のリダイレクトURLの設定
   def after_update_path_for(resource)
-    setting_path(resource)
+    setting_path
   end
 
   # The path used after sign up for inactive accounts.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,7 @@ class User < ApplicationRecord
   validates :email, uniqueness: true, unless: :line_user? # nil,空,空白禁止。emailは一意。しかしLINE登録者は対象外。presenceはオーバーライドに任せる。
   validates :provider, inclusion: { in: [ "line" ] }, allow_nil: true # "line"以外の文字は弾く。nilはOK
   validates :uid, presence: true, uniqueness: { scope: :provider }, if: :line_user? # LINE登録者の場合はnil,空,空白禁止で、provider内のuidが一意
-  validates :password, format: { without: /\s/, message: "は空白があると登録ができません" }, unless: :line_user? # nil,空,空白禁止。正規表現。しかしline登録者は対象外。presenceはオーバーライドに任せる。
+  validates :password, format: { without: /\s/, message: "は空白があると登録ができません" }, confirmation: true, unless: :line_user?, allow_blank: true # nil,空,空白禁止。正規表現。確認用フィールドと値確認。しかしline登録者は対象外。presenceはオーバーライドに任せる。
 
   # --- Userモデルのアソシエーション ---
   has_many :categories, dependent: :destroy
@@ -39,9 +39,11 @@ class User < ApplicationRecord
   end
 
   # deviseのpassword（内部）メソッドを上書き（オーバーライド）
-  # !は否定。LINEログイン経由じゃないですよね？ → その場合（true)、passwordが必要
+  # LINEログイン経由のユーザー？ → その場合（true)、passwordが必要
   def password_required?
-    !line_user?
+    return false if line_user?
+    return false if persisted? && password.blank? && password_confirmation.blank?
+    true
   end
 
   # デモユーザーかどうか判断するメソッド

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -39,7 +39,9 @@ class User < ApplicationRecord
   end
 
   # deviseのpassword（内部）メソッドを上書き（オーバーライド）
-  # LINEログイン経由のユーザー？ → その場合（true)、passwordが必要
+  # LINEログイン経由のユーザーはパスワード不要（false）
+  # 既存ユーザーがpassword/password_confirmation空欄の更新時もパスワード変更不要（false）
+  # それ以外（新規登録時など）はパスワード必須（true）
   def password_required?
     return false if line_user?
     return false if persisted? && password.blank? && password_confirmation.blank?

--- a/app/views/setting/index.html.erb
+++ b/app/views/setting/index.html.erb
@@ -5,15 +5,15 @@
 
   <!-- アカウント -->
   <section>
-    <p class="font-bold text-primary mb-2 px-1">アカウント</p>
+    <p class="text-xl font-bold text-primary mb-2 px-1">アカウント</p>
     <div class="bg-white rounded-2xl shadow-sm ring ring-light-gray">
-      <%= link_to "#", class: "card flex items-center gap-4 p-4 rounded-2xl hover:bg-light-gray transition", data: { controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" } do %>
+      <%= link_to edit_user_registration_path, class: "card flex items-center gap-4 p-4 rounded-2xl hover:bg-light-gray transition", data: { controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" } do %>
         <div class="w-10 h-10 rounded-full bg-primary/20 flex items-center justify-center text-primary">
           <span class="material-symbols-outlined text-xl">account_circle</span>
         </div>
         <div class="flex-1">
-          <p class="font-bold text-sm">プロフィール設定</p>
-          <p class="text-xs text-text-muted">名前、メールアドレス</p>
+          <p class="font-bold">プロフィール設定</p>
+          <p class="text-xs text-dark-gray">ユーザーの内容を変更できます</p>
         </div>
         <span class="material-symbols-outlined text-middle-gray">chevron_right</span>
       <% end %>
@@ -22,7 +22,7 @@
 
   <!-- マスタ管理 -->
   <section>
-    <p class="font-bold text-primary mb-2 px-1">マスタ管理</p>
+    <p class="text-xl font-bold text-primary mb-2 px-1">マスタ管理</p>
     <div class="bg-white rounded-2xl shadow-sm ring ring-light-gray">
       <!-- カテゴリーマスタ -->
       <%= link_to categories_path, class: "card shadow-none flex items-center gap-4 p-4 rounded-t-2xl hover:bg-light-gray hover:shadow-lg active:shadow-sm transition", data: { controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" } do %>
@@ -30,7 +30,7 @@
           <span class="material-symbols-outlined text-xl">category</span>
         </div>
         <div class="flex-1">
-          <p class="font-bold text-sm">カテゴリー管理</p>
+          <p class="font-bold">カテゴリー管理</p>
         </div>
         <span class="material-symbols-outlined text-middle-gray">chevron_right</span>
       <% end %>
@@ -40,7 +40,7 @@
         <div class="w-10 h-10 rounded-full bg-primary/20 flex items-center justify-center text-primary">
           <span class="material-symbols-outlined text-xl">storefront</span>
         </div>
-        <p class="flex-1 font-bold text-sm">店舗管理</p>
+        <p class="flex-1 font-bold">店舗管理</p>
         <span class="material-symbols-outlined text-middle-gray">chevron_right</span>
       <% end %>
       <hr class="border-light-gray">
@@ -49,7 +49,7 @@
         <div class="w-10 h-10 rounded-full bg-primary/20 flex items-center justify-center text-primary">
           <span class="material-symbols-outlined text-xl">speed</span>
         </div>
-        <p class="flex-1 font-bold text-sm">内容量単位管理</p>
+        <p class="flex-1 font-bold">内容量単位管理</p>
         <span class="material-symbols-outlined text-middle-gray">chevron_right</span>
       <% end %>
     </div>
@@ -58,14 +58,14 @@
 
   <!-- サポート & 情報 -->
   <section>
-    <p class="font-bold text-primary mb-2 px-1">サポート & 情報</p>
+    <p class="text-xl font-bold text-primary mb-2 px-1">サポート & 情報</p>
     <div class="bg-white rounded-2xl shadow-sm ring ring-light-gray">
       <!-- 利用規約 -->
       <%= link_to terms_path, class: "card shadow-none flex items-center gap-4 p-4 rounded-t-2xl hover:bg-light-gray hover:shadow-lg active:shadow-sm transition", data: { controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" } do %>
         <div class="w-10 h-10 rounded-full bg-primary/20 flex items-center justify-center text-primary">
           <span class="material-symbols-outlined text-xl">description</span>
         </div>
-        <p class="flex-1 font-bold text-sm">利用規約</p>
+        <p class="flex-1 font-bold">利用規約</p>
         <span class="material-symbols-outlined text-middle-gray">chevron_right</span>
       <% end %>
       <hr class="border-light-gray">
@@ -74,7 +74,7 @@
         <div class="w-10 h-10 rounded-full bg-primary/20 flex items-center justify-center text-primary">
           <span class="material-symbols-outlined text-xl">privacy_tip</span>
         </div>
-        <p class="flex-1 font-bold text-sm">プライバシーポリシー</p>
+        <p class="flex-1 font-bold">プライバシーポリシー</p>
         <span class="material-symbols-outlined text-middle-gray">chevron_right</span>
       <% end %>
       <hr class="border-light-gray">
@@ -84,7 +84,7 @@
         <div class="w-10 h-10 rounded-full bg-primary/20 flex items-center justify-center text-primary">
           <span class="material-symbols-outlined text-xl">contact_support</span>
         </div>
-        <p class="flex-1 font-bold text-sm">お問い合わせ</p>
+        <p class="flex-1 font-bold">お問い合わせ</p>
         <span class="material-symbols-outlined text-middle-gray">chevron_right</span>
       <% end %>
 

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -1,43 +1,95 @@
-<h2>Edit <%= resource_name.to_s.humanize %></h2>
+<% content_for :header_class do %>
+  bg-primary text-white
+<% end %>
+<% content_for :arrow_back do %>
+  arrow_back
+<% end %>
+<% content_for :title do %>
+  プロフィール設定
+<% end %>
 
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
   <%= render "users/shared/error_messages", resource: resource %>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+  <!-- ニックネーム -->
+  <div class="mb-5">
+    <%= f.label :name, class: "block text-black font-semibold mb-2"%>
+    <div class="flex items-center border border-light-gray rounded-xl px-3 py-3 bg-white focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition">
+      <span class="material-symbols-outlined text-middle-gray mr-2" style="font-size: 20px;">
+        account_circle
+      </span>
+      <%= f.text_field :name, autofocus: true, placeholder: "お名前", class: "flex-1 outline-none text-black bg-transparent placeholder-middle-gray" %>
+    </div>
+    <span class="text-middle-gray text-sm">※パスワードを入力しなくても変更可能です。</span>
   </div>
 
-  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
+  <!-- LINEユーザーにはメールアドレス・パスワードのフォームを表示させない -->
+  <% unless current_user.line_user? %>
+    <!-- メールアドレス -->
+    <div class="mb-5">
+      <%= f.label :email, class: "block text-middle-gray font-semibold mb-2" %>
+      <div class="flex items-center border border-light-gray rounded-xl px-3 py-3 bg-white focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition">
+        <span class="material-symbols-outlined text-middle-gray mr-2" style="font-size: 20px;">
+          mail
+        </span>
+        <%= f.email_field :email, readonly: true, class: "flex-1 outline-none text-middle-gray bg-transparent placeholder-middle-gray" %>
+      </div>
+      <span class="text-middle-gray text-sm">※メールアドレスの変更は現在対応しておりません</span>
+    </div>
+
+    <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+      <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
+    <% end %>
+
+    <!-- 変更するパスワード -->
+    <div class="mb-5">
+      <div class="flex items-center gap-1 mb-2">
+        <%= f.label :password, class: "block text-black font-semibold" %>
+        <% if @minimum_password_length %>
+          <span class="text-black font-semibold">
+            （<%= @minimum_password_length %>文字以上）
+          </span>
+        <% end %>
+      </div>
+      <div class="flex items-center border border-light-gray rounded-xl px-3 py-3 bg-white focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition">
+        <span class="material-symbols-outlined text-middle-gray mr-2" style="font-size: 20px;">lock</span>
+        <%= f.password_field :password, autocomplete: "new-password", placeholder: "••••••••", class: "flex-1 outline-none text-black bg-transparent placeholder-middle-gray" %>
+      </div>
+    </div>
+
+    <!-- 変更するパスワードの確認用 -->
+    <div class="mb-5">
+      <%= f.label :password_confirmation, class: "block text-black font-semibold mb-2" %>
+      <div class="flex items-center border border-light-gray rounded-xl px-3 py-3 bg-white focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition">
+        <span class="material-symbols-outlined text-middle-gray mr-2" style="font-size: 20px;">lock</span>
+        <%= f.password_field :password_confirmation, autocomplete: "new-password", placeholder: "••••••••", class: "flex-1 outline-none text-black bg-transparent placeholder-middle-gray" %>
+      </div>
+    </div>
+
+    <!-- 変更前の現在のパスワード -->
+    <div>
+      <%= f.label :current_password, class: "block text-black font-semibold mb-2" %>
+      <div class="flex items-center border border-light-gray rounded-xl px-3 py-3 bg-white focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition">
+        <span class="material-symbols-outlined text-middle-gray mr-2" style="font-size: 20px;">lock</span>
+        <%= f.password_field :current_password, autocomplete: "current-password", placeholder: "••••••••", class: "flex-1 outline-none text-black bg-transparent placeholder-middle-gray" %>
+      </div>
+    </div>
+    <span class="text-middle-gray text-sm">※パスワードを変更するには、現在のパスワードが必要です</span>
   <% end %>
 
-  <div class="field">
-    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
-    <% if @minimum_password_length %>
-      <br />
-      <em><%= @minimum_password_length %> characters minimum</em>
+  <div class="mt-10 mb-10 px-6">
+    <%= f.button :submit, class: "card w-full bg-primary text-white px-6 py-4 rounded-full flex items-center justify-center font-bold text-xl tracking-widest", data: { controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" } do %>
+      <%= t("devise.registrations.edit.button") %>
+      <span class="material-symbols-outlined">login</span>
     <% end %>
   </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
-    <%= f.password_field :current_password, autocomplete: "current-password" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Update" %>
-  </div>
 <% end %>
+<div class="mb-10">
+  <hr class="flex-1 border-dark-gray">
+</div>
+<div class="px-6">
+  <%= button_to registration_path(resource_name), method: :delete, form: { data: { turbo_confirm: "アカウントを本当に削除しますか？ 削除した場合、データを復元することはできません" } }, class: "w-full card bg-error text-white px-6 py-4 border-2 border-error rounded-full flex items-center justify-center font-bold", data: { controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" } do %>
+    <span class="text-xl tracking-widest">このアカウントを削除する</span>
+  <% end %>
+</div>
 
-<h3>Cancel my account</h3>
-
-<div>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" }, method: :delete %></div>
-
-<%= link_to "Back", :back %>

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -101,6 +101,7 @@ ja:
     registrations:
       destroyed: アカウントを削除しました。またのご利用をお待ちしております。
       edit:
+        button: ユーザー内容を更新する
         are_you_sure: 本当によろしいですか？
         cancel_my_account: アカウント削除
         currently_waiting_confirmation_for_email: '%{email} の確認待ち'


### PR DESCRIPTION
### 関連ISSUE
---
close #285 

### 変更内容
---
- ユーザーのニックネーム・パスワードを変更できるよう実装しました。
- メールアドレスは現時点で変更不可にしました。
- LINEユーザーは変更画面において、ニックネームのみ表示するようにしました。

### 動作確認
---
- 設定画面のプロフィール設定において、ユーザー内容を変更可能（メールアドレス以外）
- ニックネームはパスワードを入力せずに変更可
- パスワードを入力する際は、新しいパスワードとは別に、現状のパスワードも入力するように実装
- LINEユーザーでログインした場合、変更画面はニックネームのみフォームが表示されるよう調整しました。

### 補足・レビュアーへのメモ
---