### PR TITLE
エラーメッセージUI改善

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -10,9 +10,8 @@ class CategoriesController < ApplicationController
   def create
     @category = current_user.categories.new(category_params)
     if @category.save
-      redirect_to categories_path, success: "カテゴリを登録しました"
+      redirect_to categories_path, success: "カテゴリーを登録しました"
     else
-      flash.now[:error] = "カテゴリ登録に失敗しました"
       render :new, status: :unprocessable_entity
     end
   end
@@ -24,9 +23,8 @@ class CategoriesController < ApplicationController
   def update
     @category = current_user.categories.find(params[:id])
     if @category.update(category_params)
-      redirect_to categories_path, success: "カテゴリを更新しました"
+      redirect_to categories_path, success: "カテゴリーを更新しました"
     else
-      flash.now[:error] = "カテゴリの更新に失敗しました"
       render :edit, status: :unprocessable_entity
     end
   end
@@ -34,7 +32,7 @@ class CategoriesController < ApplicationController
   def destroy
     @category = current_user.categories.find(params[:id])
     @category.destroy
-    redirect_to categories_path, success: "カテゴリを削除しました", status: :see_other
+    redirect_to categories_path, success: "カテゴリーを削除しました", status: :see_other
   end
 
   private

--- a/app/controllers/content_units_controller.rb
+++ b/app/controllers/content_units_controller.rb
@@ -10,9 +10,8 @@ class ContentUnitsController < ApplicationController
   def create
     @content_unit = current_user.content_units.new(content_unit_params)
     if @content_unit.save
-      redirect_to content_units_path, success: "内容量単位を登録しました"
+      redirect_to content_units_path, success: "単位（内容量）を登録しました"
     else
-      flash.now[:error] = "内容量単位登録に失敗しました"
       render :new, status: :unprocessable_entity
     end
   end
@@ -24,9 +23,8 @@ class ContentUnitsController < ApplicationController
   def update
     @content_unit = current_user.content_units.find(params[:id])
     if @content_unit.update(content_unit_params)
-      redirect_to content_units_path, success: "内容量単位を更新しました"
+      redirect_to content_units_path, success: "単位（内容量）を更新しました"
     else
-      flash.now[:error] = "内容量単位の更新に失敗しました"
       render :edit, status: :unprocessable_entity
     end
   end
@@ -34,7 +32,7 @@ class ContentUnitsController < ApplicationController
   def destroy
     @content_unit = current_user.content_units.find(params[:id])
     if @content_unit.destroy
-      redirect_to content_units_path, success: "内容量単位を削除しました", status: :see_other
+      redirect_to content_units_path, success: "単位（内容量）を削除しました", status: :see_other
     else
       redirect_to content_units_path, alert: "購入履歴があるため削除することができません", status: :see_other
     end

--- a/app/controllers/item_registrations_controller.rb
+++ b/app/controllers/item_registrations_controller.rb
@@ -13,7 +13,6 @@ class ItemRegistrationsController < ApplicationController
     else
       @items = current_user.items.order(:name)
       @content_units = current_user.content_units.order(:name)
-      flash.now[:error] = "商品の登録に失敗しました"
       render :new, status: :unprocessable_entity
     end
   end

--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -46,7 +46,6 @@ class PurchasesController < ApplicationController
       @content_units = current_user.content_units.order(:name)
       @pack_units = current_user.pack_units.order(:name)
       @stores = current_user.stores.order(:name)
-      flash.now[:error] = "商品情報の編集に失敗しました"
       render :edit, status: :unprocessable_entity
     end
   end

--- a/app/controllers/stores_controller.rb
+++ b/app/controllers/stores_controller.rb
@@ -12,7 +12,6 @@ class StoresController < ApplicationController
     if @store.save
       redirect_to stores_path, success: "店舗を登録しました"
     else
-      flash.now[:error] = "店舗登録に失敗しました"
       render :new, status: :unprocessable_entity
     end
   end
@@ -26,7 +25,6 @@ class StoresController < ApplicationController
     if @store.update(store_params)
       redirect_to stores_path, success: "店舗を更新しました"
     else
-      flash.now[:error] = "店舗の更新に失敗しました。"
       render :edit, status: :unprocessable_entity
     end
   end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -9,7 +9,7 @@ class Category < ApplicationRecord
   belongs_to :user
   has_many :items, dependent: :nullify
 
-  # --- ransack設定 Categoryモデルのidカラムのみ検索許可（商品一覧でのカテゴリ絞り込み用） ---
+  # --- ransack設定 Categoryモデルのidカラムのみ検索許可（商品一覧でのカテゴリー絞り込み用） ---
   def self.ransackable_attributes(auth_object = nil)
     %w[id]
   end

--- a/app/views/categories/edit.html.erb
+++ b/app/views/categories/edit.html.erb
@@ -1,18 +1,19 @@
-<!-- カテゴリ編集登録 -->
+<!-- カテゴリー編集登録 -->
 <% content_for :arrow_back do %>
   arrow_back
 <% end %>
 <% content_for :title do %>
-  カテゴリ編集
+  カテゴリー編集
 <% end %>
 
 <%= form_with model: @category do |f| %>
   <%= render 'shared/error_messages', object: f.object %>
   <div class ="mb-10">
     <%= f.label :name, class: "block text-black font-bold mb-2"%>
-    <div class="flex border border-light-gray rounded-xl px-3 py-3 bg-white focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition">
+    <div class="flex border <%= f.object.errors[:name].any? ? "border-error border-2" : "border-light-gray" %> rounded-xl px-3 py-3 bg-white focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition">
       <%= f.text_field :name, placeholder: "例：飲料 / 日用品", autocomplete: "off", class: "flex-auto outline-none text-black bg-transparent placeholder-gray" %>
     </div>
+    <%= render "shared/field_error", object: f.object, field: :name %>
   </div>
   <%= f.submit "この内容で更新する", class: "card w-full bg-primary tracking-widest text-white px-6 py-4 rounded-full flex items-center justify-center font-bold no-underline", data: { controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" } %>
 <% end %>

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -12,7 +12,7 @@
     <% @categories.each do |category| %>
       <div class="swipe-card" data-controller="swipe" data-action="touchstart->swipe#touchstart touchend->swipe#touchend touchstart@document->swipe#outsideClick">
 
-        <%# カテゴリ名：常に左端に固定表示 %>
+        <%# カテゴリー名：常に左端に固定表示 %>
         <div class="absolute top-0 left-0 bottom-0 flex items-center px-5 z-10">
           <span class="text-sm font-bold text-gray-800"><%= category.name %></span>
         </div>

--- a/app/views/categories/new.html.erb
+++ b/app/views/categories/new.html.erb
@@ -3,16 +3,17 @@
   arrow_back
 <% end %>
 <% content_for :title do %>
-  カテゴリ登録
+  カテゴリー登録
 <% end %>
 
 <%= form_with model: @category do |f| %>
   <%= render 'shared/error_messages', object: f.object %>
   <div class ="mb-10">
     <%= f.label :name, class: "block text-black font-bold mb-2"%>
-    <div class="flex border border-light-gray rounded-xl px-3 py-3 bg-white focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition">
+    <div class="flex border <%= f.object.errors[:name].any? ? "border-error border-2" : "border-light-gray" %> rounded-xl px-3 py-3 bg-white focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition">
       <%= f.text_field :name, placeholder: "例：飲料 / 日用品", autocomplete: "off", class: "flex-auto outline-none text-black bg-transparent placeholder-gray" %>
     </div>
+    <%= render "shared/field_error", object: f.object, field: :name %>
   </div>
   <%= f.submit "この内容で登録する", class: "card w-full bg-primary tracking-widest text-white px-6 py-4 rounded-full flex items-center justify-center font-bold no-underline", data: { controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" } %>
 <% end %>

--- a/app/views/content_units/edit.html.erb
+++ b/app/views/content_units/edit.html.erb
@@ -1,18 +1,19 @@
-<!-- 内容量単位編集 -->
+<!-- 単位（内容量）編集 -->
 <% content_for :arrow_back do %>
   arrow_back
 <% end %>
 <% content_for :title do %>
-  内容量単位編集
+  単位（内容量）編集
 <% end %>
 
 <%= form_with model: @content_unit do |f| %>
   <%= render 'shared/error_messages', object: f.object %>
   <div class ="mb-10">
     <%= f.label :name, class: "block text-black font-bold mb-2"%>
-    <div class="flex border border-light-gray rounded-xl px-3 py-3 bg-white focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition">
+    <div class="flex border <%= f.object.errors[:name].any? ? "border-error border-2 : "border-light-gray" %> rounded-xl px-3 py-3 bg-white focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition">
       <%= f.text_field :name, placeholder: "例：g / ml / 個", autocomplete: "off", class: "flex-auto outline-none text-black bg-transparent placeholder-gray" %>
     </div>
+    <%= render "shared/field_error", object: f.object, field: :name %>
   </div>
   <%= f.submit "この内容で更新する", class: "card w-full bg-primary tracking-widest text-white px-6 py-4 rounded-full flex items-center justify-center font-bold no-underline", data: { controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" } %>
 <% end %>

--- a/app/views/content_units/edit.html.erb
+++ b/app/views/content_units/edit.html.erb
@@ -10,7 +10,7 @@
   <%= render 'shared/error_messages', object: f.object %>
   <div class ="mb-10">
     <%= f.label :name, class: "block text-black font-bold mb-2"%>
-    <div class="flex border <%= f.object.errors[:name].any? ? "border-error border-2 : "border-light-gray" %> rounded-xl px-3 py-3 bg-white focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition">
+    <div class="flex border <%= f.object.errors[:name].any? ? "border-error border-2" : "border-light-gray" %> rounded-xl px-3 py-3 bg-white focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition">
       <%= f.text_field :name, placeholder: "例：g / ml / 個", autocomplete: "off", class: "flex-auto outline-none text-black bg-transparent placeholder-gray" %>
     </div>
     <%= render "shared/field_error", object: f.object, field: :name %>

--- a/app/views/content_units/index.html.erb
+++ b/app/views/content_units/index.html.erb
@@ -13,7 +13,7 @@
     <% @content_units.each do |content_unit| %>
       <div class="swipe-card" data-controller="swipe" data-action="touchstart->swipe#touchstart touchend->swipe#touchend touchstart@document->swipe#outsideClick">
 
-        <%# カテゴリ名：常に左端に固定表示 %>
+        <%# カテゴリー名：常に左端に固定表示 %>
         <div class="absolute top-0 left-0 bottom-0 flex items-center px-5 z-10">
           <span class="text-sm font-bold text-gray-800"><%= content_unit.name %></span>
         </div>

--- a/app/views/content_units/index.html.erb
+++ b/app/views/content_units/index.html.erb
@@ -3,10 +3,10 @@
   arrow_back
 <% end %>
 <% content_for :title do %>
-  内容量単位一覧
+  単位（内容量）一覧
 <% end %>
 
-<!-- 1件以上の内容量単位が登録されている場合 -->
+<!-- 1件以上の単位（内容量）が登録されている場合 -->
 <% if @content_units.any? %>
 
   <div class="space-y-4">
@@ -43,16 +43,16 @@
   <%# 商品登録ボタン（FAB） %>
   <div class="fixed bottom-28 left-0 right-0 mx-auto max-w-xl px-6 flex justify-end z-25">
     <%= link_to new_content_unit_path, class: "card bg-primary text-white px-6 py-4 rounded-full flex items-center font-bold", data: { controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" } do %>
-      <span class="text-lg">内容量単位追加</span>
+      <span class="text-lg">単位（内容量）追加</span>
       <span class="material-symbols-outlined">add</span>
     <% end %>
   </div>
 
-<!-- 内容量単位登録が0件の場合 -->
+<!-- 単位（内容量）登録が0件の場合 -->
 <% else %>
   <div class="flex flex-col items-center text-center py-8">
     <h1 class="text-3xl font-bold text-black mb-4">
-      内容量単位がありません
+      単位（内容量）がありません
     </h1>
     <div class="mb-4 flex h-32 w-32 items-center justify-center rounded-full bg-light-gray">
       <span class="material-symbols-outlined text-dark-gray" style="font-size: 80px;">speed</span>
@@ -65,7 +65,7 @@
     <!-- 商品登録遷移ボタン -->
     <div class="w-full px-6 mb-8">
       <%= link_to new_content_unit_path, class: "card bg-primary text-white px-6 py-4 rounded-full flex items-center justify-center font-bold", data: { controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" } do %>
-        <span class="text-xl tracking-widest">内容量単位を登録する</span>
+        <span class="text-xl tracking-widest">単位（内容量）を登録する</span>
         <span class="material-symbols-outlined">add_2</span>
       <% end %>
     </div>

--- a/app/views/content_units/index.html.erb
+++ b/app/views/content_units/index.html.erb
@@ -13,7 +13,7 @@
     <% @content_units.each do |content_unit| %>
       <div class="swipe-card" data-controller="swipe" data-action="touchstart->swipe#touchstart touchend->swipe#touchend touchstart@document->swipe#outsideClick">
 
-        <%# カテゴリー名：常に左端に固定表示 %>
+        <%# 単位（内容量）：常に左端に固定表示 %>
         <div class="absolute top-0 left-0 bottom-0 flex items-center px-5 z-10">
           <span class="text-sm font-bold text-gray-800"><%= content_unit.name %></span>
         </div>

--- a/app/views/content_units/new.html.erb
+++ b/app/views/content_units/new.html.erb
@@ -1,18 +1,19 @@
-<!-- 内容量単位新規登録 -->
+<!-- 単位（内容量）新規登録 -->
 <% content_for :arrow_back do %>
   arrow_back
 <% end %>
 <% content_for :title do %>
-  内容量単位登録
+  単位（内容量）登録
 <% end %>
 
 <%= form_with model: @content_unit do |f| %>
   <%= render 'shared/error_messages', object: f.object %>
   <div class ="mb-10">
     <%= f.label :name, class: "block text-black font-bold mb-2"%>
-    <div class="flex border border-light-gray rounded-xl px-3 py-3 bg-white focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition">
+    <div class="flex border <%= f.object.errors[:name].any? ? "border-error border-2" : "border-light-gray" %> rounded-xl px-3 py-3 bg-white focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition">
       <%= f.text_field :name, placeholder: "例：g / ml / 個", autocomplete: "off", class: "flex-auto outline-none text-black bg-transparent placeholder-gray" %>
     </div>
+    <%= render "shared/field_error", object: f.object, field: :name %>
   </div>
   <%= f.submit "この内容で登録する", class: "card w-full bg-primary tracking-widest text-white px-6 py-4 rounded-full flex items-center justify-center font-bold no-underline", data: { controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" } %>
 <% end %>

--- a/app/views/item_registrations/complete.html.erb
+++ b/app/views/item_registrations/complete.html.erb
@@ -63,7 +63,7 @@
         </div>
         <div class="flex-1 min-w-0">
           <p class="font-medium text-black m-0">詳細情報を追加する</p>
-          <p class="text-sm text-middle-gray mt-0.5">店舗・カテゴリなど（任意）</p>
+          <p class="text-sm text-middle-gray mt-0.5">店舗・カテゴリーなど（任意）</p>
         </div>
         <span class="material-symbols-outlined text-middle-gray">chevron_right</span>
       <% end %>

--- a/app/views/item_registrations/new.html.erb
+++ b/app/views/item_registrations/new.html.erb
@@ -26,7 +26,7 @@
 
         <!-- 商品名 -->
         <%= f.label :item_name, class: "block text-black font-bold mb-2"%>
-        <div class="form <%= "border-error border-2 focus-within:border-primary focus-within:ring-1 focus-within:ring-primary" if f.object.errors[:content_unit_name].any? %> flex mb-0">
+        <div class="form <%= "border-error border-2 focus-within:border-primary focus-within:ring-1 focus-within:ring-primary" if f.object.errors[:item_name].any? %> flex mb-0">
           <%= f.text_field :item_name, placeholder: "例：牛乳 / 箱ティッシュ", autocomplete: "off", list: "items_list", class: "flex-auto outline-none text-black bg-transparent placeholder-gray", data: { restore_values_target: "itemName", action: "change->restore-values#restoreValues" } %>
           <datalist id="items_list">
             <% @items.each do |item| %>
@@ -51,7 +51,7 @@
           <!-- 内容量 -->
           <div>
             <%= f.label :content_quantity, class: "block text-black font-bold mb-2"%>
-            <div class="form <%= "border-error border-2 focus-within:border-primary focus-within:ring-1 focus-within:ring-primary" if f.object.errors[:content_unit_name].any? %>">
+            <div class="form <%= "border-error border-2 focus-within:border-primary focus-within:ring-1 focus-within:ring-primary" if f.object.errors[:content_quantity].any? %>">
               <%= f.number_field :content_quantity, placeholder: "例：3 , 500", autocomplete: "off", inputmode: "decimal", step: 0.01, class: "w-full flex-auto outline-none text-black bg-transparent placeholder-gray", data: { restore_values_target: "contentQuantity" } %>
             </div>
             <%= render "shared/field_error", object: f.object, field: :content_quantity %>

--- a/app/views/item_registrations/new.html.erb
+++ b/app/views/item_registrations/new.html.erb
@@ -26,7 +26,7 @@
 
         <!-- 商品名 -->
         <%= f.label :item_name, class: "block text-black font-bold mb-2"%>
-        <div class="form <%= "border-error border-2" if f.object.errors[:content_unit_name].any? %> flex mb-0">
+        <div class="form <%= "border-error border-2 focus-within:border-primary focus-within:ring-1 focus-within:ring-primary" if f.object.errors[:content_unit_name].any? %> flex mb-0">
           <%= f.text_field :item_name, placeholder: "例：牛乳 / 箱ティッシュ", autocomplete: "off", list: "items_list", class: "flex-auto outline-none text-black bg-transparent placeholder-gray", data: { restore_values_target: "itemName", action: "change->restore-values#restoreValues" } %>
           <datalist id="items_list">
             <% @items.each do |item| %>
@@ -51,7 +51,7 @@
           <!-- 内容量 -->
           <div>
             <%= f.label :content_quantity, class: "block text-black font-bold mb-2"%>
-            <div class="form <%= "border-error border-2" if f.object.errors[:content_unit_name].any? %>">
+            <div class="form <%= "border-error border-2 focus-within:border-primary focus-within:ring-1 focus-within:ring-primary" if f.object.errors[:content_unit_name].any? %>">
               <%= f.number_field :content_quantity, placeholder: "例：3 , 500", autocomplete: "off", inputmode: "decimal", step: 0.01, class: "w-full flex-auto outline-none text-black bg-transparent placeholder-gray", data: { restore_values_target: "contentQuantity" } %>
             </div>
             <%= render "shared/field_error", object: f.object, field: :content_quantity %>
@@ -60,7 +60,7 @@
           <!-- 単位（内容量） -->
           <div>
             <%= f.label :content_unit_name, class: "block text-black font-bold mb-2"%>
-            <div class="form <%= "border-error border-2" if f.object.errors[:content_unit_name].any? %>">
+            <div class="form <%= "border-error border-2 focus-within:border-primary focus-within:ring-1 focus-within:ring-primary" if f.object.errors[:content_unit_name].any? %>">
               <%= f.text_field :content_unit_name, placeholder: "例：ml、g", autocomplete: "off", list: "content_units_list", class: "w-full flex-auto outline-none text-black bg-transparent placeholder-gray", data: { restore_values_target: "contentUnit" } %>
               <datalist id="content_units_list">
                 <% @content_units.each do |unit| %>
@@ -79,7 +79,7 @@
 
         <!-- ユーザーが入力する価格 -->
         <%= f.label :price, class: "block text-black font-bold mb-2"%>
-        <div class="form <%= "border-error border-2" if f.object.errors[:price].any? %> flex mb-0">
+        <div class="form <%= "border-error border-2 focus-within:border-primary focus-within:ring-1 focus-within:ring-primary" if f.object.errors[:price].any? %> flex mb-0">
           <%= f.number_field :price, placeholder: "例：298 / 1200", autocomplete: "off", inputmode: "numeric", class: "flex-auto outline-none text-black bg-transparent placeholder-gray" %>
         </div>
         <%= render "shared/field_error", object: f.object, field: :price %>

--- a/app/views/item_registrations/new.html.erb
+++ b/app/views/item_registrations/new.html.erb
@@ -21,12 +21,12 @@
     <div class="space-y-6">
 
       <!-- 商品情報カード -->
-      <h1 class="text-xl font-bold border-b  text-primary border-primary pb-2">商品情報</h1>
+      <h1 class="text-xl font-bold border-b text-primary border-primary pb-2">商品情報</h1>
       <div class="bg-white rounded-2xl border border-light-gray p-4 space-y-4">
 
         <!-- 商品名 -->
         <%= f.label :item_name, class: "block text-black font-bold mb-2"%>
-        <div class="form flex">
+        <div class="form <%= "border-error border-2" if f.object.errors[:content_unit_name].any? %> flex mb-0">
           <%= f.text_field :item_name, placeholder: "例：牛乳 / 箱ティッシュ", autocomplete: "off", list: "items_list", class: "flex-auto outline-none text-black bg-transparent placeholder-gray", data: { restore_values_target: "itemName", action: "change->restore-values#restoreValues" } %>
           <datalist id="items_list">
             <% @items.each do |item| %>
@@ -34,6 +34,8 @@
             <% end %>
           </datalist>
         </div>
+        <%= render "shared/field_error", object: f.object, field: :item_name %>
+
 
         <!-- 前回の値が反映された際の通知メッセージ -->
         <div data-restore-values-target="message" 
@@ -41,6 +43,7 @@
           <span>✓</span>
           <span>前回の登録内容を反映しました</span>
         </div>
+        <div class="mb-4"></div>
 
         <!-- 2列 -->
         <div class="grid grid-cols-2 gap-2">
@@ -48,15 +51,16 @@
           <!-- 内容量 -->
           <div>
             <%= f.label :content_quantity, class: "block text-black font-bold mb-2"%>
-            <div class="form">
+            <div class="form <%= "border-error border-2" if f.object.errors[:content_unit_name].any? %>">
               <%= f.number_field :content_quantity, placeholder: "例：3 , 500", autocomplete: "off", inputmode: "decimal", step: 0.01, class: "w-full flex-auto outline-none text-black bg-transparent placeholder-gray", data: { restore_values_target: "contentQuantity" } %>
             </div>
+            <%= render "shared/field_error", object: f.object, field: :content_quantity %>
           </div>
 
           <!-- 単位（内容量） -->
           <div>
             <%= f.label :content_unit_name, class: "block text-black font-bold mb-2"%>
-            <div class="form">
+            <div class="form <%= "border-error border-2" if f.object.errors[:content_unit_name].any? %>">
               <%= f.text_field :content_unit_name, placeholder: "例：ml、g", autocomplete: "off", list: "content_units_list", class: "w-full flex-auto outline-none text-black bg-transparent placeholder-gray", data: { restore_values_target: "contentUnit" } %>
               <datalist id="content_units_list">
                 <% @content_units.each do |unit| %>
@@ -64,6 +68,7 @@
                 <% end %>
               </datalist>
             </div>
+            <%= render "shared/field_error", object: f.object, field: :content_unit_name %>
           </div>
         </div>
       </div>
@@ -74,9 +79,11 @@
 
         <!-- ユーザーが入力する価格 -->
         <%= f.label :price, class: "block text-black font-bold mb-2"%>
-        <div class="form flex">
+        <div class="form <%= "border-error border-2" if f.object.errors[:price].any? %> flex mb-0">
           <%= f.number_field :price, placeholder: "例：298 / 1200", autocomplete: "off", inputmode: "numeric", class: "flex-auto outline-none text-black bg-transparent placeholder-gray" %>
         </div>
+        <%= render "shared/field_error", object: f.object, field: :price %>
+        <div class="mb-4"></div>
 
         <!-- 消費税率 -->
         <%= f.label :tax_rate, class: "block text-black font-bold mb-2"%>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -15,11 +15,11 @@
       </div>
     <% end %>
   </div>
-  <!-- カテゴリの選択絞り込み -->
+  <!-- カテゴリーの選択絞り込み -->
   <div class="mb-4 flex gap-2 overflow-auto pb-1" style="scrollbar-width: thin;">
     <%= link_to "全て", items_path, class: "flex-shrink-0 px-4 py-1.5 rounded-full text-sm font-bold whitespace-nowrap #{params.dig(:q, :category_id_eq).blank? && params.dig(:q, :category_id_null) != "1" ? 'bg-primary text-white' : 'bg-white text-middle-gray border border-light-gray'}" %>
 
-    <!-- カテゴリごとのチップ -->
+    <!-- カテゴリーごとのチップ -->
     <% @categories.each do |category| %>
       <%= link_to category.name,
           items_path(q: { category_id_eq: category.id }),

--- a/app/views/purchases/edit.html.erb
+++ b/app/views/purchases/edit.html.erb
@@ -23,7 +23,7 @@
 
       <!-- カテゴリー名 -->
       <%= f.label :category_name, class: "block text-black font-bold mb-2"%>
-      <div class="form flex">
+      <div class="form <%= "border-error border-2" if f.object.errors[:category_name].any? %> flex mb-0">
         <%= f.text_field :category_name, placeholder: "例：飲料 / 日用品", autocomplete: "off", list: "categories_list", class: "flex-auto outline-none text-black bg-transparent placeholder-gray" %>
         <datalist id="categories_list">
           <% @categories.each do |category| %>
@@ -31,10 +31,12 @@
           <% end %>
         </datalist>
       </div>
+      <%= render "shared/field_error", object: f.object, field: :category_name %>
+      <div class="mb-4"></div>
 
       <!-- 商品名 -->
       <%= f.label :item_name, class: "block text-black font-bold mb-2"%>
-      <div class="form flex">
+      <div class="form <%= "border-error border-2" if f.object.errors[:item_name].any? %> flex mb-0">
         <%= f.text_field :item_name, placeholder: "例：牛乳 / 箱ティッシュ", autocomplete: "off", list: "items_list", class: "flex-auto outline-none text-black bg-transparent placeholder-gray" %>
         <datalist id="items_list">
           <% @items.each do |item| %>
@@ -42,10 +44,12 @@
           <% end %>
         </datalist>
       </div>
+      <%= render "shared/field_error", object: f.object, field: :item_name %>
+      <div class="mb-4"></div>
 
       <!-- 店舗名 -->
       <%= f.label :store_name, class: "block text-black font-bold mb-2"%>
-      <div class="form flex">
+      <div class="form <%= "border-error border-2" if f.object.errors[:store_name].any? %> flex mb-0">
         <%= f.text_field :store_name, placeholder: "例：〇〇スーパー〇〇店", autocomplete: "off", list: "stores_list", class: "flex-auto outline-none text-black bg-transparent placeholder-gray" %>
         <datalist id="stores_list">
           <% @stores.each do |store| %>
@@ -53,10 +57,12 @@
           <% end %>
         </datalist>
       </div>
+      <%= render "shared/field_error", object: f.object, field: :store_name %>
+      <div class="mb-4"></div>
 
       <!-- ブランド名 -->
       <%= f.label :brand, class: "block text-black font-bold mb-2"%>
-      <div class="form flex">
+      <div class="form <%= "border-error border-2" if f.object.errors[:brand].any? %> flex mb-0">
         <%= f.text_field :brand, placeholder: "例：伊藤園 / 花王", autocomplete: "off", list: "brands_list", class: "flex-auto outline-none text-black bg-transparent placeholder-gray" %>
         <datalist id="brands_list">
           <% @brands.each do |brand| %>
@@ -64,6 +70,8 @@
           <% end %>
         </datalist>
       </div>
+      <%= render "shared/field_error", object: f.object, field: :brand %>
+      <div class="mb-4"></div>
 
       <!-- 2列 -->
       <div class="grid grid-cols-2 gap-2">
@@ -71,15 +79,16 @@
         <!-- 内容量 -->
         <div>
           <%= f.label :content_quantity, class: "block text-black font-bold mb-2"%>
-          <div class="form">
+          <div class="form <%= "border-error border-2" if f.object.errors[:content_quantity].any? %>">
             <%= f.number_field :content_quantity, placeholder: "例：3 / 500", autocomplete: "off", inputmode: "decimal", step: 0.01, class: "w-full flex-auto outline-none text-black bg-transparent placeholder-gray" %>
           </div>
+          <%= render "shared/field_error", object: f.object, field: :content_quantity %>
         </div>
 
         <!-- 単位（内容量） -->
         <div>
           <%= f.label :content_unit_name, class: "block text-black font-bold mb-2"%>
-          <div class="form">
+          <div class="form <%= "border-error border-2" if f.object.errors[:content_unit_name].any? %>">
             <%= f.text_field :content_unit_name, placeholder: "例：ml / g", autocomplete: "off", list: "content_units_list", class: "w-full flex-auto outline-none text-black bg-transparent placeholder-gray" %>
             <datalist id="content_units_list">
               <% @content_units.each do |unit| %>
@@ -87,20 +96,22 @@
               <% end %>
             </datalist>
           </div>
+          <%= render "shared/field_error", object: f.object, field: :content_unit_name %>
         </div>
 
         <!-- 包装数 -->
         <div>
           <%= f.label :pack_quantity, class: "block text-black font-bold mb-2"%>
-          <div class="form">
+          <div class="form <%= "border-error border-2" if f.object.errors[:pack_quantity].any? %>">
             <%= f.number_field :pack_quantity, placeholder: "例：1 / 6", autocomplete: "off", inputmode: "numeric", class: "w-full flex-auto outline-none text-black bg-transparent placeholder-gray" %>
           </div>
+          <%= render "shared/field_error", object: f.object, field: :pack_quantity %>
         </div>
 
         <!-- 単位（包装数） -->
         <div>
           <%= f.label :pack_unit_name, class: "block text-black font-bold mb-2"%>
-          <div class="form">
+          <div class="form <%= "border-error border-2" if f.object.errors[:pack_unit_name].any? %>">
             <%= f.text_field :pack_unit_name, placeholder: "例：セット / 箱", autocomplete: "off", list: "pack_units_list", class: "w-full flex-auto outline-none text-black bg-transparent placeholder-gray" %>
             <datalist id="pack_units_list">
               <% @pack_units.each do |unit| %>
@@ -108,14 +119,17 @@
               <% end %>
             </datalist>
           </div>
+          <%= render "shared/field_error", object: f.object, field: :pack_unit_name %>
         </div>
       </div>
 
       <!-- 登録日 -->
       <%= f.label :purchased_on, class: "block text-black font-bold mb-2"%>
-      <div class="form flex">
+      <div class="form <%= "border-error border-2" if f.object.errors[:purchased_on].any? %> flex mb-0">
         <%= f.date_field :purchased_on, class: "flex-auto outline-none text-black bg-transparent" %>
       </div>
+      <%= render "shared/field_error", object: f.object, field: :purchased_on %>
+      <div class="mb-4"></div>
     </div>
 
     <!-- 価格情報カード -->
@@ -124,9 +138,11 @@
 
       <!-- ユーザーが入力する価格 -->
       <%= f.label :price, class: "block text-black font-bold mb-2"%>
-      <div class="form flex">
+      <div class="form <%= "border-error border-2" if f.object.errors[:price].any? %> flex mb-0">
         <%= f.number_field :price, placeholder: "例：298 / 1200", autocomplete: "off", inputmode: "numeric", class: "flex-auto outline-none text-black bg-transparent placeholder-gray" %>
       </div>
+      <%= render "shared/field_error", object: f.object, field: :price %>
+      <div class="mb-4"></div>
 
       <!-- 消費税率 -->
       <%= f.label :tax_rate, class: "block text-black font-bold mb-2"%>

--- a/app/views/purchases/edit.html.erb
+++ b/app/views/purchases/edit.html.erb
@@ -23,7 +23,7 @@
 
       <!-- カテゴリー名 -->
       <%= f.label :category_name, class: "block text-black font-bold mb-2"%>
-      <div class="form <%= "border-error border-2" if f.object.errors[:category_name].any? %> flex mb-0">
+      <div class="form <%= "border-error border-2 focus-within:border-primary focus-within:ring-1 focus-within:ring-primary" if f.object.errors[:category_name].any? %> flex mb-0">
         <%= f.text_field :category_name, placeholder: "例：飲料 / 日用品", autocomplete: "off", list: "categories_list", class: "flex-auto outline-none text-black bg-transparent placeholder-gray" %>
         <datalist id="categories_list">
           <% @categories.each do |category| %>
@@ -36,7 +36,7 @@
 
       <!-- 商品名 -->
       <%= f.label :item_name, class: "block text-black font-bold mb-2"%>
-      <div class="form <%= "border-error border-2" if f.object.errors[:item_name].any? %> flex mb-0">
+      <div class="form <%= "border-error border-2 focus-within:border-primary focus-within:ring-1 focus-within:ring-primary" if f.object.errors[:item_name].any? %> flex mb-0">
         <%= f.text_field :item_name, placeholder: "例：牛乳 / 箱ティッシュ", autocomplete: "off", list: "items_list", class: "flex-auto outline-none text-black bg-transparent placeholder-gray" %>
         <datalist id="items_list">
           <% @items.each do |item| %>
@@ -49,7 +49,7 @@
 
       <!-- 店舗名 -->
       <%= f.label :store_name, class: "block text-black font-bold mb-2"%>
-      <div class="form <%= "border-error border-2" if f.object.errors[:store_name].any? %> flex mb-0">
+      <div class="form <%= "border-error border-2 focus-within:border-primary focus-within:ring-1 focus-within:ring-primary" if f.object.errors[:store_name].any? %> flex mb-0">
         <%= f.text_field :store_name, placeholder: "例：〇〇スーパー〇〇店", autocomplete: "off", list: "stores_list", class: "flex-auto outline-none text-black bg-transparent placeholder-gray" %>
         <datalist id="stores_list">
           <% @stores.each do |store| %>
@@ -62,7 +62,7 @@
 
       <!-- ブランド名 -->
       <%= f.label :brand, class: "block text-black font-bold mb-2"%>
-      <div class="form <%= "border-error border-2" if f.object.errors[:brand].any? %> flex mb-0">
+      <div class="form <%= "border-error border-2 focus-within:border-primary focus-within:ring-1 focus-within:ring-primary" if f.object.errors[:brand].any? %> flex mb-0">
         <%= f.text_field :brand, placeholder: "例：伊藤園 / 花王", autocomplete: "off", list: "brands_list", class: "flex-auto outline-none text-black bg-transparent placeholder-gray" %>
         <datalist id="brands_list">
           <% @brands.each do |brand| %>
@@ -79,7 +79,7 @@
         <!-- 内容量 -->
         <div>
           <%= f.label :content_quantity, class: "block text-black font-bold mb-2"%>
-          <div class="form <%= "border-error border-2" if f.object.errors[:content_quantity].any? %>">
+          <div class="form <%= "border-error border-2 focus-within:border-primary focus-within:ring-1 focus-within:ring-primary" if f.object.errors[:content_quantity].any? %>">
             <%= f.number_field :content_quantity, placeholder: "例：3 / 500", autocomplete: "off", inputmode: "decimal", step: 0.01, class: "w-full flex-auto outline-none text-black bg-transparent placeholder-gray" %>
           </div>
           <%= render "shared/field_error", object: f.object, field: :content_quantity %>
@@ -88,7 +88,7 @@
         <!-- 単位（内容量） -->
         <div>
           <%= f.label :content_unit_name, class: "block text-black font-bold mb-2"%>
-          <div class="form <%= "border-error border-2" if f.object.errors[:content_unit_name].any? %>">
+          <div class="form <%= "border-error border-2 focus-within:border-primary focus-within:ring-1 focus-within:ring-primary" if f.object.errors[:content_unit_name].any? %>">
             <%= f.text_field :content_unit_name, placeholder: "例：ml / g", autocomplete: "off", list: "content_units_list", class: "w-full flex-auto outline-none text-black bg-transparent placeholder-gray" %>
             <datalist id="content_units_list">
               <% @content_units.each do |unit| %>
@@ -102,7 +102,7 @@
         <!-- 包装数 -->
         <div>
           <%= f.label :pack_quantity, class: "block text-black font-bold mb-2"%>
-          <div class="form <%= "border-error border-2" if f.object.errors[:pack_quantity].any? %>">
+          <div class="form <%= "border-error border-2 focus-within:border-primary focus-within:ring-1 focus-within:ring-primary" if f.object.errors[:pack_quantity].any? %>">
             <%= f.number_field :pack_quantity, placeholder: "例：1 / 6", autocomplete: "off", inputmode: "numeric", class: "w-full flex-auto outline-none text-black bg-transparent placeholder-gray" %>
           </div>
           <%= render "shared/field_error", object: f.object, field: :pack_quantity %>
@@ -111,7 +111,7 @@
         <!-- 単位（包装数） -->
         <div>
           <%= f.label :pack_unit_name, class: "block text-black font-bold mb-2"%>
-          <div class="form <%= "border-error border-2" if f.object.errors[:pack_unit_name].any? %>">
+          <div class="form <%= "border-error border-2 focus-within:border-primary focus-within:ring-1 focus-within:ring-primary" if f.object.errors[:pack_unit_name].any? %>">
             <%= f.text_field :pack_unit_name, placeholder: "例：セット / 箱", autocomplete: "off", list: "pack_units_list", class: "w-full flex-auto outline-none text-black bg-transparent placeholder-gray" %>
             <datalist id="pack_units_list">
               <% @pack_units.each do |unit| %>
@@ -125,7 +125,7 @@
 
       <!-- 登録日 -->
       <%= f.label :purchased_on, class: "block text-black font-bold mb-2"%>
-      <div class="form <%= "border-error border-2" if f.object.errors[:purchased_on].any? %> flex mb-0">
+      <div class="form <%= "border-error border-2 focus-within:border-primary focus-within:ring-1 focus-within:ring-primary" if f.object.errors[:purchased_on].any? %> flex mb-0">
         <%= f.date_field :purchased_on, class: "flex-auto outline-none text-black bg-transparent" %>
       </div>
       <%= render "shared/field_error", object: f.object, field: :purchased_on %>
@@ -138,7 +138,7 @@
 
       <!-- ユーザーが入力する価格 -->
       <%= f.label :price, class: "block text-black font-bold mb-2"%>
-      <div class="form <%= "border-error border-2" if f.object.errors[:price].any? %> flex mb-0">
+      <div class="form <%= "border-error border-2 focus-within:border-primary focus-within:ring-1 focus-within:ring-primary" if f.object.errors[:price].any? %> flex mb-0">
         <%= f.number_field :price, placeholder: "例：298 / 1200", autocomplete: "off", inputmode: "numeric", class: "flex-auto outline-none text-black bg-transparent placeholder-gray" %>
       </div>
       <%= render "shared/field_error", object: f.object, field: :price %>

--- a/app/views/purchases/edit.html.erb
+++ b/app/views/purchases/edit.html.erb
@@ -21,7 +21,7 @@
     <h1 class="text-xl font-bold border-b text-primary border-primary pb-2">商品情報</h1>
     <div class="bg-white rounded-2xl border border-light-gray p-4 space-y-4">
 
-      <!-- カテゴリ名 -->
+      <!-- カテゴリー名 -->
       <%= f.label :category_name, class: "block text-black font-bold mb-2"%>
       <div class="form flex">
         <%= f.text_field :category_name, placeholder: "例：飲料 / 日用品", autocomplete: "off", list: "categories_list", class: "flex-auto outline-none text-black bg-transparent placeholder-gray" %>

--- a/app/views/setting/index.html.erb
+++ b/app/views/setting/index.html.erb
@@ -49,7 +49,7 @@
         <div class="w-10 h-10 rounded-full bg-primary/20 flex items-center justify-center text-primary">
           <span class="material-symbols-outlined text-xl">speed</span>
         </div>
-        <p class="flex-1 font-bold">内容量単位管理</p>
+        <p class="flex-1 font-bold">単位（内容量）管理</p>
         <span class="material-symbols-outlined text-middle-gray">chevron_right</span>
       <% end %>
     </div>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,9 +1,6 @@
+<!-- バリデーションエラー時「〇〇（モデル名）登録に失敗しました」メッセージ表示 -->
 <% if object.errors.any? %>
   <div class="mx-4 mt-4 rounded-lg border p-4 mb-4 text-sm font-bold bg-flash-error-bg text-flash-error-text">
-    <% object.errors.each do |error| %>
-      <ul class="list-disc list-inside">
-        <li><%= error.full_message %></li>
-      </ul>
-    <% end %>
+    <%= object.class.model_name.human %>登録に失敗しました
   </div>
 <% end %>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,6 +1,6 @@
 <!-- バリデーションエラー時「〇〇（モデル名）登録に失敗しました」メッセージ表示 -->
 <% if object.errors.any? %>
   <div class="mx-4 mt-4 rounded-lg border p-4 mb-4 text-sm font-bold bg-flash-error-bg text-flash-error-text">
-    <%= object.class.model_name.human %>登録に失敗しました
+    <%= object.class.model_name.human %><%= object.new_record? ? "登録" : "更新" %>に失敗しました
   </div>
 <% end %>

--- a/app/views/shared/_field_error.html.erb
+++ b/app/views/shared/_field_error.html.erb
@@ -1,0 +1,6 @@
+<!-- バリデーションエラー時、フォーム直下エラー詳細メッセージ表示 -->
+<% if object.errors[field].any? %>
+  <p class= "mt-1 text-sm font-bold text-flash-error-text">
+    <%= object.errors.full_messages_for(field).first %>
+  </p>
+<% end %>

--- a/app/views/stores/edit.html.erb
+++ b/app/views/stores/edit.html.erb
@@ -10,9 +10,10 @@
   <%= render 'shared/error_messages', object: f.object %>
   <div class ="mb-10">
     <%= f.label :name, class: "block text-black font-bold mb-2"%>
-    <div class="flex border border-light-gray rounded-xl px-3 py-3 bg-white focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition">
+    <div class="flex border <%= f.object.errors[:name].any? ? "border-error border-2" : "border-light-gray" %> rounded-xl px-3 py-3 bg-white focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition">
       <%= f.text_field :name, placeholder: "例：〇〇スーパー〇〇店 / 〇〇薬局", autocomplete: "off", class: "flex-auto outline-none text-black bg-transparent placeholder-gray" %>
     </div>
+    <%= render "shared/field_error", object: f.object, field: :name %>
   </div>
   <%= f.submit "この内容で更新する", class: "card w-full bg-primary tracking-widest text-white px-6 py-4 rounded-full flex items-center justify-center font-bold no-underline", data: { controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" } %>
 <% end %>

--- a/app/views/stores/new.html.erb
+++ b/app/views/stores/new.html.erb
@@ -10,9 +10,10 @@
   <%= render 'shared/error_messages', object: f.object %>
   <div class ="mb-10">
     <%= f.label :name, class: "block text-black font-bold mb-2"%>
-    <div class="flex border border-light-gray rounded-xl px-3 py-3 bg-white focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition">
+    <div class="flex border <%= f.object.errors[:name].any? ? "border-error border-2" : "border-light-gray" %> rounded-xl px-3 py-3 bg-white focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition">
       <%= f.text_field :name, placeholder: "例：〇〇スーパー〇〇店 / 〇〇薬局", autocomplete: "off", class: "flex-auto outline-none text-black bg-transparent placeholder-gray" %>
     </div>
+    <%= render "shared/field_error", object: f.object, field: :name %>
   </div>
   <%= f.submit "この内容で登録する", class: "card w-full bg-primary tracking-widest text-white px-6 py-4 rounded-full flex items-center justify-center font-bold no-underline", data: { controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" } %>
 <% end %>

--- a/app/views/users/passwords/edit.html.erb
+++ b/app/views/users/passwords/edit.html.erb
@@ -4,11 +4,11 @@
   bg-primary text-white
 <% end %>
 
+<%= render "users/shared/error_messages", resource: resource, message: "パスワードの変更に失敗しました" %>
 <div class="flex flex-col md:flex-row items-center justify-center gap-6">
   <div class="bg-white rounded-2xl border border-light-gray w-full p-4">
     <h2 class="text-center text-2xl font-bold text-black mb-6"><%= t("devise.passwords.edit.change_your_password") %></h2>
     <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
-      <%= render "users/shared/error_messages", resource: resource %>
       <%= f.hidden_field :reset_password_token %>
 
       <div class="mb-5">
@@ -20,18 +20,20 @@
             </span>
           <% end %>
         </div>
-        <div class="flex items-center border border-light-gray rounded-xl px-3 py-3 bg-white focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition">
+        <div class="flex items-center border <%= f.object.errors[:password].any? ? "border-error border-2" : "border-light-gray" %> rounded-xl px-3 py-3 bg-white focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition">
           <span class="material-symbols-outlined text-middle-gray mr-2" style="font-size: 20px;">lock</span>
           <%= f.password_field :password, autocomplete: "new-password", placeholder: "••••••••", class: "flex-1 outline-none text-gray-700 bg-transparent placeholder-gray-400" %>
         </div>
+        <%= render "shared/field_error", object: f.object, field: :password %>
       </div>
 
       <div class="mb-10">
         <%= f.label :password_confirmation, class: "block text-black font-semibold mb-2" %>
-        <div class="flex items-center border border-light-gray rounded-xl px-3 py-3 bg-white focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition">
+        <div class="flex items-center border <%= f.object.errors[:password_confirmation].any? ? "border-error border-2" : "border-light-gray" %> rounded-xl px-3 py-3 bg-white focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition">
           <span class="material-symbols-outlined text-middle-gray mr-2" style="font-size: 20px;">lock</span>
           <%= f.password_field :password_confirmation, autocomplete: "new-password", placeholder: "••••••••", class: "flex-1 outline-none text-gray-700 bg-transparent placeholder-gray-400" %>
         </div>
+        <%= render "shared/field_error", object: f.object, field: :password_confirmation %>
       </div>
 
       <div class="mb-10 px-2">

--- a/app/views/users/passwords/new.html.erb
+++ b/app/views/users/passwords/new.html.erb
@@ -6,21 +6,23 @@
 <% content_for :arrow_back do %>
   arrow_back
 <% end %>
+
+<%= render "users/shared/error_messages", resource: resource, message: "メールの送信に失敗しました" %>
 <div class="flex flex-col md:flex-row items-center justify-center gap-6">
   <div class="bg-white rounded-2xl border border-light-gray w-full p-4">
     <h2 class="text-center text-2xl font-bold text-black mb-6"><%= t("devise.passwords.new.forgot_your_password") %></h2>
 
     <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-      <%= render "users/shared/error_messages", resource: resource %>
 
       <div class="mb-10">
         <%= f.label :email, class: "block text-black font-semibold mb-2"%>
-        <div class="flex items-center border border-light-gray rounded-xl px-3 py-3 bg-white focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition">
+        <div class="flex items-center border <%= f.object.errors[:email].any? ? "border-error border-2" : "border-light-gray" %> rounded-xl px-3 py-3 bg-white focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition">
           <span class="material-symbols-outlined text-middle-gray mr-2" style="font-size: 20px;">
             mail
           </span>
           <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "example@email.com", required: true,  class: "flex-1 outline-none text-gray-700 bg-transparent placeholder-gray-400" %>
         </div>
+        <%= render "shared/field_error", object: f.object, field: :email %>
       </div>
 
       <div class="mb-10 px-2">

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -9,17 +9,18 @@
 <% end %>
 
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "users/shared/error_messages", resource: resource %>
+  <%= render "users/shared/error_messages", resource: resource, message: "プロフィールの変更に失敗しました" %>
 
   <!-- ニックネーム -->
   <div class="mb-5">
     <%= f.label :name, class: "block text-black font-semibold mb-2"%>
-    <div class="flex items-center border border-light-gray rounded-xl px-3 py-3 bg-white focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition">
+    <div class="flex items-center border <%= f.object.errors[:name].any? ? "border-error border-2" : "border-light-gray" %> rounded-xl px-3 py-3 bg-white focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition">
       <span class="material-symbols-outlined text-middle-gray mr-2" style="font-size: 20px;">
         account_circle
       </span>
       <%= f.text_field :name, autofocus: true, placeholder: "お名前", class: "flex-1 outline-none text-black bg-transparent placeholder-middle-gray" %>
     </div>
+    <%= render "shared/field_error", object: f.object, field: :name %>
     <span class="text-middle-gray text-sm">※パスワードを入力しなくても変更可能です。</span>
   </div>
 
@@ -51,29 +52,32 @@
           </span>
         <% end %>
       </div>
-      <div class="flex items-center border border-light-gray rounded-xl px-3 py-3 bg-white focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition">
+      <div class="flex items-center border <%= f.object.errors[:password].any? ? "border-error border-2" : "border-light-gray" %> rounded-xl px-3 py-3 bg-white focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition">
         <span class="material-symbols-outlined text-middle-gray mr-2" style="font-size: 20px;">lock</span>
         <%= f.password_field :password, autocomplete: "new-password", placeholder: "••••••••", class: "flex-1 outline-none text-black bg-transparent placeholder-middle-gray" %>
       </div>
+      <%= render "shared/field_error", object: f.object, field: :password %>
     </div>
 
     <!-- 変更するパスワードの確認用 -->
     <div class="mb-5">
       <%= f.label :password_confirmation, class: "block text-black font-semibold mb-2" %>
-      <div class="flex items-center border border-light-gray rounded-xl px-3 py-3 bg-white focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition">
+      <div class="flex items-center border <%= f.object.errors[:password_confirmation].any? ? "border-error border-2" : "border-light-gray" %> rounded-xl px-3 py-3 bg-white focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition">
         <span class="material-symbols-outlined text-middle-gray mr-2" style="font-size: 20px;">lock</span>
         <%= f.password_field :password_confirmation, autocomplete: "new-password", placeholder: "••••••••", class: "flex-1 outline-none text-black bg-transparent placeholder-middle-gray" %>
       </div>
+      <%= render "shared/field_error", object: f.object, field: :password_confirmation %>
     </div>
 
     <!-- 変更前の現在のパスワード -->
     <div>
       <%= f.label :current_password, class: "block text-black font-semibold mb-2" %>
-      <div class="flex items-center border border-light-gray rounded-xl px-3 py-3 bg-white focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition">
+      <div class="flex items-center border <%= f.object.errors[:current_password].any? ? "border-error border-2" : "border-light-gray" %> rounded-xl px-3 py-3 bg-white focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition">
         <span class="material-symbols-outlined text-middle-gray mr-2" style="font-size: 20px;">lock</span>
         <%= f.password_field :current_password, autocomplete: "current-password", placeholder: "••••••••", class: "flex-1 outline-none text-black bg-transparent placeholder-middle-gray" %>
       </div>
     </div>
+    <%= render "shared/field_error", object: f.object, field: :current_password %>
     <span class="text-middle-gray text-sm">※パスワードを変更するには、現在のパスワードが必要です</span>
   <% end %>
 

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -6,31 +6,34 @@
 <% content_for :arrow_back do %>
   arrow_back
 <% end %>
+
+<%= render "users/shared/error_messages", resource: resource, message: "アカウントの登録に失敗しました" %>
 <div class="flex flex-col md:flex-row items-center justify-center gap-6">
   <div class="bg-white rounded-2xl border border-light-gray w-full p-4">
     <h2 class="text-center text-2xl font-bold text-black my-6"><%= t("devise.registrations.new.sign_up") %></h2>
 
     <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-      <%= render "users/shared/error_messages", resource: resource %>
 
       <div class="mb-5">
         <%= f.label :name, class: "block text-black font-semibold mb-2"%>
-        <div class="flex items-center border border-light-gray rounded-xl px-3 py-3 bg-white focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition">
+        <div class="flex items-center border <%= f.object.errors[:name].any? ? "border-error border-2" : "border-light-gray" %> rounded-xl px-3 py-3 bg-white focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition">
           <span class="material-symbols-outlined text-middle-gray mr-2" style="font-size: 20px;">
             account_circle
           </span>
           <%= f.text_field :name, autofocus: true, placeholder: "お名前", class: "flex-1 outline-none text-black bg-transparent placeholder-gray-400"%>
         </div>
+        <%= render "shared/field_error", object: f.object, field: :name %>
       </div>
 
       <div class="mb-5">
         <%= f.label :email, class: "block text-black font-semibold mb-2"%>
-        <div class="flex items-center border border-light-gray rounded-xl px-3 py-3 bg-white focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition">
+        <div class="flex items-center border <%= f.object.errors[:email].any? ? "border-error border-2" : "border-light-gray" %> rounded-xl px-3 py-3 bg-white focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition">
           <span class="material-symbols-outlined text-middle-gray mr-2" style="font-size: 20px;">
             mail
           </span>
           <%= f.email_field :email, placeholder: "example@email.com", class: "flex-1 outline-none text-black bg-transparent placeholder-gray-400" %>
         </div>
+        <%= render "shared/field_error", object: f.object, field: :email %>
       </div>
 
       <div class="mb-5">
@@ -42,18 +45,20 @@
             </span>
           <% end %>
         </div>
-        <div class="flex items-center border border-light-gray rounded-xl px-3 py-3 bg-white focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition">
+        <div class="flex items-center border <%= f.object.errors[:password].any? ? "border-error border-2" : "border-light-gray" %> rounded-xl px-3 py-3 bg-white focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition">
           <span class="material-symbols-outlined text-middle-gray mr-2" style="font-size: 20px;">lock</span>
           <%= f.password_field :password, autocomplete: "new-password", placeholder: "••••••••", class: "flex-1 outline-none text-gray-700 bg-transparent placeholder-gray-400" %>
         </div>
+        <%= render "shared/field_error", object: f.object, field: :password %>
       </div>
 
       <div class="mb-10">
         <%= f.label :password_confirmation, class: "block text-black font-semibold mb-2" %>
-        <div class="flex items-center border border-light-gray rounded-xl px-3 py-3 bg-white focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition">
+        <div class="flex items-center border <%= f.object.errors[:password_confirmation].any? ? "border-error border-2" : "border-light-gray" %> rounded-xl px-3 py-3 bg-white focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition">
           <span class="material-symbols-outlined text-middle-gray mr-2" style="font-size: 20px;">lock</span>
           <%= f.password_field :password_confirmation, autocomplete: "new-password", placeholder: "••••••••", class: "flex-1 outline-none text-gray-700 bg-transparent placeholder-gray-400" %>
         </div>
+        <%= render "shared/field_error", object: f.object, field: :password_confirmation %>
       </div>
 
       <!-- 利用規約・プライバシーポリシー同意チェック -->

--- a/app/views/users/shared/_error_messages.html.erb
+++ b/app/views/users/shared/_error_messages.html.erb
@@ -1,15 +1,5 @@
 <% if resource.errors.any? %>
   <div id="error_explanation" data-turbo-cache="false" class="mx-4 mt-4 rounded-lg border p-4 mb-4 text-sm font-bold bg-flash-error-bg text-flash-error-text" >
-      <h2>
-        <%= I18n.t("errors.messages.not_saved",
-                  count: resource.errors.count,
-                  resource: resource.class.model_name.human.downcase)
-        %>
-      </h2>
-      <ul>
-        <% resource.errors.full_messages.each do |message| %>
-          <li><%= message %></li>
-        <% end %>
-      </ul>
-    </div>
+    <%= message %>
+  </div>
 <% end %>

--- a/app/views/users/shared/_omniauth_links.html.erb
+++ b/app/views/users/shared/_omniauth_links.html.erb
@@ -1,11 +1,9 @@
 <!-- LINEログイン用遷移（POST送信のため、button_toで実装 --> 
 <%- if devise_mapping.omniauthable? %>
   <%- resource_class.omniauth_providers.each do |provider| %>
-    <%= button_to omniauth_authorize_path(resource_name, provider), method: :post, data: { turbo: false, controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" }, class: "card w-full bg-[#06C755] rounded-full relative flex items-center my-5 py-4 px-6" do %>
-      <div class="absolute left-0 top-0 flex items-center justify-center w-14 h-14 border-r border-black/[0.08]">
-        <%= image_tag "btn_base.png", class: "w-10 h-10" %>
-      </div>
-      <span class="flex-1 text-white text-xl font-bold tracking-widest">
+    <%= button_to omniauth_authorize_path(resource_name, provider), method: :post, data: { turbo: false, controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" }, class: "card w-full bg-[#06C755] rounded-full flex items-center justify-center gap-3 my-5 py-4 px-6" do %>
+      <%= image_tag "btn_base.png", class: "w-7 h-7" %>
+      <span class="text-white text-xl font-bold tracking-widest">
         <%= controller_name == "registrations" ? "LINEで新規登録" : "LINEでログイン" %>
       </span>
     <% end %>

--- a/app/views/users/shared/_omniauth_links.html.erb
+++ b/app/views/users/shared/_omniauth_links.html.erb
@@ -2,7 +2,7 @@
 <%- if devise_mapping.omniauthable? %>
   <%- resource_class.omniauth_providers.each do |provider| %>
     <%= button_to omniauth_authorize_path(resource_name, provider), method: :post, data: { turbo: false, controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" }, class: "card w-full bg-[#06C755] rounded-full flex items-center justify-center gap-3 my-5 py-4 px-6" do %>
-      <%= image_tag "btn_base.png", class: "w-7 h-7" %>
+      <%= image_tag "btn_base.png", class: "w-7 h-7", alt: "" %>
       <span class="text-white text-xl font-bold tracking-widest">
         <%= controller_name == "registrations" ? "LINEで新規登録" : "LINEでログイン" %>
       </span>

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,5 +24,9 @@ module Myapp
     # config.eager_load_paths << Rails.root.join("extras")
     # 日本語表記
     config.i18n.default_locale = :ja
+
+    # エラーがあるフィールドをどう装飾するか」を決める関数(Proc)
+    # バリデーションエラー時のデフォルトの装飾を無効化
+    config.action_view.field_error_proc = ->(html_tag, instance) { html_tag.html_safe }
   end
 end

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -152,4 +152,4 @@ ja:
       not_found: は見つかりませんでした。
       not_locked: はロックされていません。
       not_saved:
-        other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした。"
+        other: アカウント登録に失敗しました

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -17,7 +17,7 @@ ja:
       store:
         name: 店舗名
       category:
-        name: カテゴリ名
+        name: カテゴリー名
       item:
         name: 商品名
       purchase:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -6,7 +6,7 @@ ja:
       category: カテゴリー
       item: 商品
       purchase: 購入履歴
-      content_unit: 単位（単位名）
+      content_unit: 単位（内容量）
       pack_unit: 単位（包装）
     attributes:
       user:
@@ -28,9 +28,9 @@ ja:
         tax_rate: 消費税
         purchased_on: 購入日
       content_unit:
-        name: 単位名（内容量）
+        name: 単位（内容量）
       pack_unit:
-        name: 単位名（包装）
+        name: 単位（包装）
   footer:
     index: 一覧
     comparison: 比較

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -37,6 +37,9 @@ ja:
     photo: 写真
     setting: 設定
   activemodel:
+    models:
+      item_registration_form: 商品
+      purchase_update_form: 購入履歴の詳細
     attributes:
       item_registration_form:
         item_name: 商品名

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,7 @@ Rails.application.routes.draw do
   # 店舗一覧・登録・編集・削除
   resources :stores, except: [ :show ]
 
-  # 内容量単位一覧・登録・編集・削除
+  # 単位（内容量）一覧・登録・編集・削除
   resources :content_units, except: [ :show ]
 
   # 商品一覧・購入履歴用（一覧・削除 / 一覧・編集・削除）

--- a/db/migrate/20260414005113_add_unit_refs_to_purchases.rb
+++ b/db/migrate/20260414005113_add_unit_refs_to_purchases.rb
@@ -1,6 +1,6 @@
 class AddUnitRefsToPurchases < ActiveRecord::Migration[7.2]
   def change
-    add_column :purchases, :content_unit_id, :bigint # 内容量単位のid追加（この時点ではnull許可）
+    add_column :purchases, :content_unit_id, :bigint # 単位（内容量）のid追加（この時点ではnull許可）
     add_column :purchases, :pack_unit_id, :bigint # パック単位のid追加
 
     # インデックス追加

--- a/lib/tasks/guest.rake
+++ b/lib/tasks/guest.rake
@@ -16,7 +16,7 @@ namespace :demo do
       demo.content_units.destroy_all
       demo.pack_units.destroy_all
 
-      # カテゴリ
+      # カテゴリー
       categories = {}
       %w[飲料 日用品 お肉 野菜 調味料 お菓子].each do |name|
         categories[name] = demo.categories.create!(name: name)

--- a/lib/tasks/guest.rake
+++ b/lib/tasks/guest.rake
@@ -28,7 +28,7 @@ namespace :demo do
         stores[name] = demo.stores.create!(name: name)
       end
 
-      # 内容量単位
+      # 単位（内容量）
       content_units = {}
       %w[ml g 枚 個 ロール].each do |name|
         content_units[name] = demo.content_units.create!(name: name)

--- a/spec/factories/content_units.rb
+++ b/spec/factories/content_units.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :content_unit do
-    sequence(:name) { |n| "内容量単位#{n}" }
+    sequence(:name) { |n| "単位（内容量）#{n}" }
     user
   end
 end


### PR DESCRIPTION
### 関連ISSUE
---
close #195 

### 変更内容
---
- 各フォーム画面にてエラーメッセージを視覚的に見やすく修正しました。
  - フォーム枠を赤色に変更
  - フォーム下にエラーメッセージ出力

- 変更したフォーム画面
  - ユーザー新規登録
  - ユーザーログイン
  - パスワード変更時の、メールアドレス送信
  - パスワードリセット
  - ユーザー編集
  - 商品登録
  - 購入履歴編集
  - カテゴリ登録・編集
  - 店舗登録・編集
  - 単位（内容量）登録・編集

### 動作確認
---
- 上記変更フォーム画面にて、エラーを出力させた際に、フォーム枠とフォーム下に赤色で枠とエラーメッセージが出力されます。

### 補足・レビュアーへのメモ
---
LINEボタンのデザインを一部修正しました。