### PR TITLE
feat: カスタムエラーページ（404 / 500）の実装

### DIFF
--- a/app/views/pwa/service-worker.js
+++ b/app/views/pwa/service-worker.js
@@ -1,10 +1,10 @@
 // Add a service worker for processing Web Push notifications:
-//
+// 
 // self.addEventListener("push", async (event) => {
 //   const { title, options } = await event.data.json()
 //   event.waitUntil(self.registration.showNotification(title, options))
 // })
-//
+// 
 // self.addEventListener("notificationclick", function(event) {
 //   event.notification.close()
 //   event.waitUntil(
@@ -12,12 +12,12 @@
 //       for (let i = 0; i < clientList.length; i++) {
 //         let client = clientList[i]
 //         let clientPath = (new URL(client.url)).pathname
-//
+// 
 //         if (clientPath == event.notification.data.path && "focus" in client) {
 //           return client.focus()
 //         }
 //       }
-//
+// 
 //       if (clients.openWindow) {
 //         return clients.openWindow(event.notification.data.path)
 //       }

--- a/public/404.html
+++ b/public/404.html
@@ -1,67 +1,71 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <title>The page you were looking for doesn't exist (404)</title>
-  <meta name="viewport" content="width=device-width,initial-scale=1">
-  <style>
-  .rails-default-error-page {
-    background-color: #EFEFEF;
-    color: #2E2F30;
-    text-align: center;
-    font-family: arial, sans-serif;
-    margin: 0;
-  }
+  <head>
+    <title><404 - ページが見つかりません | SokoNote ></title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
 
-  .rails-default-error-page div.dialog {
-    width: 95%;
-    max-width: 33em;
-    margin: 4em auto 0;
-  }
+      body {
+        background-color: #FCFDF7;
+        color: #333333;
+        font-family: sans-serif;
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        padding: 16px;
+      }
 
-  .rails-default-error-page div.dialog > div {
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #BBB;
-    border-top: #B00100 solid 4px;
-    border-top-left-radius: 9px;
-    border-top-right-radius: 9px;
-    background-color: white;
-    padding: 7px 12% 0;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
-  }
+      .error-number {
+        font-size: 80px;
+        font-weight: bold;
+        color: #6EA016;
+        line-height: 1;
+        margin-bottom: 16px;
+      }
 
-  .rails-default-error-page h1 {
-    font-size: 100%;
-    color: #730E15;
-    line-height: 1.5em;
-  }
+      .error-title {
+        font-size: 20px;
+        font-weight: bold;
+        color: #333333;
+        margin-bottom: 8px;
+      }
 
-  .rails-default-error-page div.dialog > p {
-    margin: 0 0 1em;
-    padding: 1em;
-    background-color: #F7F7F7;
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #999;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
-    border-top-color: #DADADA;
-    color: #666;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
-  }
-  </style>
-</head>
+      .error-message {
+        font-size: 14px;
+        color: #818181;
+        margin-bottom: 32px;
+      }
 
-<body class="rails-default-error-page">
-  <!-- This file lives in public/404.html -->
-  <div class="dialog">
-    <div>
-      <h1>The page you were looking for doesn't exist.</h1>
-      <p>You may have mistyped the address or the page may have moved.</p>
-    </div>
-    <p>If you are the application owner check the logs for more information.</p>
-  </div>
-</body>
+      .home-button {
+        background-color: #6EA016;
+        color: #FDFDFD;
+        padding: 12px 32px;
+        border-radius: 9999px;
+        text-decoration: none;
+        font-weight: bold;
+        font-size: 16px;
+        box-shadow: 0 4px 6px rgba(0, 0, 0, 0.4);
+        transition: opacity 0.2s;
+      }
+
+      .home-button:hover {
+        opacity: 0.85;
+      }
+    </style>
+  </head>
+  <body>
+    <p class="error-number">404</p>
+    <p class="error-title">ページが見つかりませんでした</p>
+    <p class="error-message">お探しのページは存在しないか、移動した可能性があります。</p>
+    <a href="/" class="home-button">トップページに戻る</a>
+  </body>
 </html>

--- a/public/404.html
+++ b/public/404.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
-<html>
+<html lang="ja">
   <head>
-    <title><404 - ページが見つかりません | SokoNote ></title>
+    <title>404 - ページが見つかりません | SokoNote </title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="apple-mobile-web-app-capable" content="yes">

--- a/public/500.html
+++ b/public/500.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="ja">
   <head>
     <title>500 - サーバーエラー | SokoNote</title>
     <meta charset="utf-8">

--- a/public/500.html
+++ b/public/500.html
@@ -1,66 +1,72 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <title>We're sorry, but something went wrong (500)</title>
-  <meta name="viewport" content="width=device-width,initial-scale=1">
-  <style>
-  .rails-default-error-page {
-    background-color: #EFEFEF;
-    color: #2E2F30;
-    text-align: center;
-    font-family: arial, sans-serif;
-    margin: 0;
-  }
+  <head>
+    <title>500 - サーバーエラー | SokoNote</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
 
-  .rails-default-error-page div.dialog {
-    width: 95%;
-    max-width: 33em;
-    margin: 4em auto 0;
-  }
+      body {
+        background-color: #FCFDF7;
+        color: #333333;
+        font-family: sans-serif;
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        padding: 16px;
+      }
 
-  .rails-default-error-page div.dialog > div {
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #BBB;
-    border-top: #B00100 solid 4px;
-    border-top-left-radius: 9px;
-    border-top-right-radius: 9px;
-    background-color: white;
-    padding: 7px 12% 0;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
-  }
+      .error-number {
+        font-size: 80px;
+        font-weight: bold;
+        color: #E65540;
+        line-height: 1;
+        margin-bottom: 16px;
+      }
 
-  .rails-default-error-page h1 {
-    font-size: 100%;
-    color: #730E15;
-    line-height: 1.5em;
-  }
+      .error-title {
+        font-size: 20px;
+        font-weight: bold;
+        color: #333333;
+        margin-bottom: 8px;
+      }
 
-  .rails-default-error-page div.dialog > p {
-    margin: 0 0 1em;
-    padding: 1em;
-    background-color: #F7F7F7;
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #999;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
-    border-top-color: #DADADA;
-    color: #666;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
-  }
-  </style>
-</head>
+      .error-message {
+        font-size: 14px;
+        color: #818181;
+        margin-bottom: 32px;
+        text-align: center;
+      }
 
-<body class="rails-default-error-page">
-  <!-- This file lives in public/500.html -->
-  <div class="dialog">
-    <div>
-      <h1>We're sorry, but something went wrong.</h1>
-    </div>
-    <p>If you are the application owner check the logs for more information.</p>
-  </div>
-</body>
+      .home-button {
+        background-color: #6EA016;
+        color: #FDFDFD;
+        padding: 12px 32px;
+        border-radius: 9999px;
+        text-decoration: none;
+        font-weight: bold;
+        font-size: 16px;
+        box-shadow: 0 4px 6px rgba(0, 0, 0, 0.4);
+        transition: opacity 0.2s;
+      }
+
+      .home-button:hover {
+        opacity: 0.85;
+      }
+    </style>
+  </head>
+  <body>
+    <p class="error-number">500</p>
+    <p class="error-title">サーバーエラーが発生しました</p>
+    <p class="error-message">申し訳ありません。しばらく時間をおいてから<br>再度お試しください。</p>
+    <a href="/" class="home-button">トップページに戻る</a>
+  </body>
 </html>


### PR DESCRIPTION
### 関連ISSUE
---
close #208

### 変更内容
---
- 本番環境でのエラー発生時、無機質なエラー表示ではなく、マイカスタムのエラー表示を実装しました。
- 404（存在しないページにアクセスした場合）、500（アプリ内部で予期しないエラーが発生した場合）の2つ実装しました。
- 上記エラーが発生した場合、トップ画面に戻るリンクボタンを実装しました。

### 動作確認
---
- 404エラーは存在しないURLを入力し、カスタムしたエラー画面を確認
- 500エラーはNeonを夜中一時的に停止し、エラー画面を確認
- どちらの画面においてもボタンを選択するとトップ画面に戻るか確認 

### 補足・レビュアーへのメモ
---