### PR TITLE
フッターナビゲーションの状態表示・導線を調整

### DIFF
--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,10 +1,16 @@
 <footer class="fixed bottom-0 left-0 w-full bg-white border-t border-light-gray z-30">
-  <nav class="flex justify-around items-center h-20 pb-5 max-w-xl mx-auto">
+  <nav class="flex justify-around items-center h-20 pb-3 max-w-xl mx-auto">
     
     <!--「商品一覧画面」に遷移する内容 -->
     <%= link_to items_path, class: "flex flex-col items-center #{active_class('items', 'purchases')}" do %>
       <span class="material-symbols-outlined">list_alt</span>
       <span class="text-xs mt-1"><%= t('footer.index') %></span>
+    <% end %>
+
+    <!-- 「商品登録画面」に遷移する内容 -->
+    <%= link_to new_item_registration_path, class: "flex flex-col items-center #{active_class('item_registrations')}" do %>
+      <span class="material-symbols-outlined text-28">add_2</span>
+      <span class="text-xs mt-1"><%= t('footer.item_registration') %></span>
     <% end %>
 
     <!--「商品比較画面」に遷移する内容 -->
@@ -13,17 +19,9 @@
       <span class="text-xs mt-1"><%= t('footer.comparison') %></span>
     <% end %>
 
-    <!--「チラシ撮影画面」に遷移する内容（現在はURLを"#"としています） -->
-    <%= link_to "#", class: "flex flex-col items-center #{active_class('#')}" do %>
-      <div class="flex flex-col items-center cursor-not-allowed relative group">
-        <span class="material-symbols-outlined text-28 group-hover:invisible">photo_camera</span>
-        <span class="text-xs mt-1 group-hover:invisible"><%= t('footer.photo') %></span>
-        <span class="text-[10px] absolute bottom-1 text-center bg-gray-200 px-1 rounded invisible group-hover:visible">coming soon</span>
-      </div>
-    <% end %>
     
     <!--「設定画面」に遷移する内容 -->
-    <%= link_to setting_path, class: "flex flex-col items-center #{active_class('setting')}" do %>
+    <%= link_to setting_path, class: "flex flex-col items-center #{active_class('setting', 'categories', 'content_units', 'privacy_policy', 'stores', 'terms', 'registrations')}" do %>
       <span class="material-symbols-outlined text-28">settings</span>
       <span class="text-xs mt-1"> <%= t('footer.setting') %></span>
     <% end %>

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -42,7 +42,7 @@ ja:
       send_instructions: アカウントの有効化について数分以内にメールでご連絡します。
       send_paranoid_instructions: メールアドレスが登録済みの場合、本人確認用のメールが数分以内に送信されます。
     failure:
-      already_authenticated: 前回のアカウントでログインしました。
+      already_authenticated: ""
       inactive: アカウントが有効化されていません。メールに記載された手順にしたがって、アカウントを有効化してください。
       invalid: "%{authentication_keys}またはパスワードが違います。"
       last_attempt: もう一回誤るとアカウントがロックされます。

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -42,7 +42,7 @@ ja:
       send_instructions: アカウントの有効化について数分以内にメールでご連絡します。
       send_paranoid_instructions: メールアドレスが登録済みの場合、本人確認用のメールが数分以内に送信されます。
     failure:
-      already_authenticated: すでにログインしています。
+      already_authenticated: 前回のアカウントでログインしました。
       inactive: アカウントが有効化されていません。メールに記載された手順にしたがって、アカウントを有効化してください。
       invalid: "%{authentication_keys}またはパスワードが違います。"
       last_attempt: もう一回誤るとアカウントがロックされます。

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -33,8 +33,8 @@ ja:
         name: 単位（包装）
   footer:
     index: 一覧
+    item_registration: 登録
     comparison: 比較
-    photo: 写真
     setting: 設定
   activemodel:
     models:


### PR DESCRIPTION
### 関連ISSUE
---
close #306 

### 変更内容
---
- ログイン後の全画面において、フッターの配色を設定しました。

### 動作確認
---
- フッター表示時には、ログイン後の全画面において、一覧・登録・比較・設定のいずれかのタグが主要な緑色に変更される。選択されていない時は、グレー。
- 

### 補足・レビュアーへのメモ
---
再度自動ログイン時のフラッシュメッセージがエラー表示だったので削除しました。