### PR TITLE
比較画面の表示UI改善

### DIFF
--- a/app/controllers/item_registrations_controller.rb
+++ b/app/controllers/item_registrations_controller.rb
@@ -1,6 +1,11 @@
 class ItemRegistrationsController < ApplicationController
   def new
-    @form = ItemRegistrationForm.new
+    purchase_params = if params[:purchase_a].present?
+                        params[:purchase_a].permit(:item_name, :content_quantity, :content_unit_name, :price, :tax_rate)
+                      elsif params[:purchase_b].present?
+                        params[:purchase_b].permit(:item_name, :content_quantity, :content_unit_name, :price, :tax_rate)
+                      end
+    @form = ItemRegistrationForm.new(purchase_params)
     @items = current_user.items.order(:name)
     @content_units = current_user.content_units.order(:name)
   end

--- a/app/controllers/item_registrations_controller.rb
+++ b/app/controllers/item_registrations_controller.rb
@@ -1,10 +1,11 @@
 class ItemRegistrationsController < ApplicationController
   def new
-    purchase_params = if params[:purchase_a].present?
-                        params[:purchase_a].permit(:item_name, :content_quantity, :content_unit_name, :price, :tax_rate)
-                      elsif params[:purchase_b].present?
-                        params[:purchase_b].permit(:item_name, :content_quantity, :content_unit_name, :price, :tax_rate)
-                      end
+    purchase_params =
+      if params[:purchase_a].present?
+        params[:purchase_a].permit(:item_name, :content_quantity, :content_unit_name, :price, :tax_rate)
+      elsif params[:purchase_b].present?
+        params[:purchase_b].permit(:item_name, :content_quantity, :content_unit_name, :price, :tax_rate)
+      end
     @form = ItemRegistrationForm.new(purchase_params)
     @items = current_user.items.order(:name)
     @content_units = current_user.content_units.order(:name)

--- a/app/javascript/controllers/compare_controller.js
+++ b/app/javascript/controllers/compare_controller.js
@@ -67,12 +67,12 @@ export default class extends Controller {
     }
 
     if (a < b) {
-        this.compareResultItemTarget.textContent = `A商品の方が${(b - a).toFixed(2)}円安い！`
+        this.compareResultItemTarget.textContent = `Aの方が${(b - a).toFixed(2)}円安い！`
         this.cardATarget.classList.add("border-primary", "border-2", "shadow-lg")
         this.badgeATarget.classList.remove("invisible")
         this.compareResultItemTarget.classList.remove("invisible")
     } else if (b < a) {
-        this.compareResultItemTarget.textContent = `B商品の方が${(a - b).toFixed(2)}円安い！`
+        this.compareResultItemTarget.textContent = `Bの方が${(a - b).toFixed(2)}円安い！`
         this.cardBTarget.classList.add("border-primary", "border-2", "shadow-lg")
         this.badgeBTarget.classList.remove("invisible")
         this.compareResultItemTarget.classList.remove("invisible")

--- a/app/javascript/controllers/restore_values_controller.js
+++ b/app/javascript/controllers/restore_values_controller.js
@@ -19,12 +19,12 @@ export default class extends Controller {
 
     let restored = false
 
-    if (data.content_quantity) {
+    if (data.content_quantity && !this.contentQuantityTarget.value) {
       this.contentQuantityTarget.value = data.content_quantity
       this.highlight(this.contentQuantityTarget)
       restored = true
     }
-    if (data.content_unit_name) {
+    if (data.content_unit_name && !this.contentUnitTarget.value) {
       this.contentUnitTarget.value = data.content_unit_name
       this.highlight(this.contentUnitTarget)
       restored = true

--- a/app/views/comparison/index.html.erb
+++ b/app/views/comparison/index.html.erb
@@ -9,10 +9,10 @@
 <div data-controller="compare">
 
   <%# ─── 比較入力エリア ─── %>
-  <div class="grid grid-cols-2 gap-4 relative">
+  <div class="grid grid-cols-2 gap-2 relative">
 
     <%# ─── 商品A（内容量・パック数・価格のフォーム） ─── %>
-    <div class="bg-white rounded-2xl px-4 pb-4 pt-2 border border-light-gray shadow-sm "data-compare-target="cardA">
+    <div class="bg-white rounded-2xl p-2 border border-light-gray shadow-sm "data-compare-target="cardA">
       <div class="invisible text-center h-7" data-compare-target="badgeA">
         <span class="bg-primary text-white text-xs font-bold px-3 py-1 rounded-full">おトク！</span>
       </div>
@@ -22,19 +22,19 @@
         <div>
           <%= f.label :content_quantity, "内容量" ,class: "text-black" %>
           <div class="mt-1 flex items-center border border-light-gray rounded-lg bg-white focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition">
-            <%= f.number_field :content_quantity, placeholder: "例：500", class: "w-full p-2 bg-transparent outline-none text-black", data: {compare_target: "contentquantityA", action: "input->compare#calculate"} %>
+            <%= f.number_field :content_quantity, placeholder: "例：500", inputmode: "decimal", class: "w-full p-2 bg-transparent outline-none text-black", data: {compare_target: "contentquantityA", action: "input->compare#calculate"} %>
           </div>
         </div>
         <div>
           <%= f.label :pack_quantity, "パック数", class: "text-black" %>
           <div class="mt-1 flex items-center border border-light-gray rounded-lg bg-white focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition">
-            <%= f.number_field :pack_quantity, placeholder: "例：3", class: "w-full p-2 bg-transparent outline-none text-black", data: {compare_target: "packquantityA", action: "input->compare#calculate" } %>
+            <%= f.number_field :pack_quantity, placeholder: "例：3", inputmode: "numeric", class: "w-full p-2 bg-transparent outline-none text-black", data: {compare_target: "packquantityA", action: "input->compare#calculate" } %>
           </div>
         </div>
         <div>
           <%= f.label :price, "価格", class: "text-black" %>
           <div class="mt-1 flex items-center border border-light-gray rounded-lg bg-white focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition">
-            <%= f.number_field :price, placeholder: "例：598", class: "w-full p-2 bg-transparent outline-none text-black", data: {compare_target: "priceA", action: "input->compare#calculate" } %>
+            <%= f.number_field :price, placeholder: "例：598", inputmode: "numeric", class: "w-full p-2 bg-transparent outline-none text-black", data: {compare_target: "priceA", action: "input->compare#calculate" } %>
           </div>
         </div>
         <div>
@@ -65,20 +65,20 @@
         </div>
 
         <div class="mt-4 p-4 bg-light-gray/50 rounded-xl text-center">
-          <p class="text-sm text-middle-gray">単価（税抜）</p>
+          <p class="text-sm text-dark-gray">単価（税抜）</p>
           <p class="text-2xl font-bold text-back">
             <span data-compare-target="resultA">---</span>
             <span class="text-sm font-normal">円</span>
           </p>
         </div>
-        <div class="mt-4 p-4 flex justify-center">
-          <%= f.submit "Aを登録する", class: "text-base w-full p-2 md:px-4 py-3 rounded-full border border-primary text-primary hover:bg-primary hover:text-white"%>
+        <div class="mt-4 mb-2 flex justify-center">
+          <%= f.submit "Aで登録する", class: "card w-full bg-primary tracking-widest text-white px-6 py-4 rounded-full flex items-center justify-center font-bold no-underline", data: { controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" } %>
         </div>
       <% end %>
     </div>
 
     <%# ─── 商品B（内容量・パック数・価格のフォーム） ─── %>
-    <div class="bg-white rounded-2xl px-4 pb-4 pt-2 border border-light-gray shadow-sm " data-compare-target="cardB">
+    <div class="bg-white rounded-2xl p-2 border border-light-gray shadow-sm " data-compare-target="cardB">
       <div class="invisible text-center h-7" data-compare-target="badgeB">
         <span class="bg-primary text-white text-xs font-bold px-3 py-1 rounded-full">おトク！</span>
       </div>
@@ -87,19 +87,19 @@
         <div>
           <%= f.label :content_quantity, "内容量" ,class: "text-black" %>
           <div class="mt-1 flex items-center border border-light-gray rounded-lg bg-white focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition">
-            <%= f.number_field :content_quantity, placeholder: "例：500", class: "w-full p-2 bg-transparent outline-none text-black", data: {compare_target: "contentquantityB", action: "input->compare#calculate" } %>
+            <%= f.number_field :content_quantity, placeholder: "例：500", inputmode: "decimal", class: "w-full p-2 bg-transparent outline-none text-black", data: {compare_target: "contentquantityB", action: "input->compare#calculate" } %>
           </div>
         </div>
         <div>
           <%= f.label :pack_quantity, "パック数", class: "text-black" %>
           <div class="mt-1 flex items-center border border-light-gray rounded-lg bg-white focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition">
-            <%= f.number_field :pack_quantity, placeholder: "例：3", class: "w-full p-2 bg-transparent outline-none text-black", data: {compare_target: "packquantityB", action: "input->compare#calculate" } %>
+            <%= f.number_field :pack_quantity, placeholder: "例：3", inputmode: "numeric", class: "w-full p-2 bg-transparent outline-none text-black", data: {compare_target: "packquantityB", action: "input->compare#calculate" } %>
           </div>
         </div>
         <div>
           <%= f.label :price, "価格", class: "text-black" %>
           <div class="mt-1 flex items-center border border-light-gray rounded-lg bg-white focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition">
-            <%= f.number_field :price, placeholder: "例：598", class: "w-full p-2 bg-transparent outline-none text-black", data: {compare_target: "priceB", action: "input->compare#calculate" } %>
+            <%= f.number_field :price, placeholder: "例：598", inputmode: "numeric", class: "w-full p-2 bg-transparent outline-none text-black", data: {compare_target: "priceB", action: "input->compare#calculate" } %>
           </div>
         </div>
         <div>
@@ -130,14 +130,14 @@
         </div>
 
         <div class="mt-4 p-4 bg-light-gray/50 rounded-xl text-center">
-          <p class="text-sm text-middle-gray">単価（税抜）</p>
+          <p class="text-sm text-dark-gray">単価（税抜）</p>
           <p class="text-2xl font-bold text-back">
             <span data-compare-target="resultB">---</span>
             <span class="text-sm font-normal">円</span>
           </p>
         </div>
-        <div class="mt-4 p-4 flex justify-center">
-          <%= f.submit "Bを登録する", class: "text-base w-full p-2 md:px-4 py-3 rounded-full border border-primary text-primary hover:bg-primary hover:text-white"%>
+        <div class="mt-4 mb-2 flex justify-center">
+          <%= f.submit "Bで登録する", class: "card w-full bg-primary tracking-widest text-white px-6 py-4 rounded-full flex items-center justify-center font-bold no-underline", data: { controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" } %>
         </div>
       <% end %>
     </div>

--- a/app/views/comparison/index.html.erb
+++ b/app/views/comparison/index.html.erb
@@ -100,11 +100,12 @@
         <% if @purchase_a&.content_unit %>
           <%= f.hidden_field :content_unit_name, value: @purchase_a.content_unit.name %>
         <% end %>
+        <div>
           <%= f.label :content_quantity, "内容量" ,class: "text-black" %>
           <div class="mt-1 flex items-center border border-light-gray rounded-lg bg-white focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition">
             <%= f.number_field :content_quantity, placeholder: "例：500", inputmode: "decimal", class: "w-full p-2 bg-transparent outline-none text-black", data: {compare_target: "contentquantityB", action: "input->compare#calculate" } %>
           </div>
-        </>
+        </div>
         <div>
           <%= f.label :pack_quantity, "パック数", class: "text-black" %>
           <div class="mt-1 flex items-center border border-light-gray rounded-lg bg-white focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition">

--- a/app/views/comparison/index.html.erb
+++ b/app/views/comparison/index.html.erb
@@ -16,9 +16,17 @@
       <div class="invisible text-center h-7" data-compare-target="badgeA">
         <span class="bg-primary text-white text-xs font-bold px-3 py-1 rounded-full">おトク！</span>
       </div>
-      <h2 class="text-xl font-bold text-center mb-3">商品A</h2>
+      <h2 class="text-xl font-bold text-center mb-3">
+        <%= @purchase_a&.item&.name || "商品" %>A
+      </h2>
 
       <%= form_with model: @purchase_a, url: new_item_registration_path, method: :get, scope: :purchase_a, class: "space-y-4" do |f| %>
+        <% if @purchase_a&.item %>
+          <%= f.hidden_field :item_name, value: @purchase_a.item.name %>
+        <% end %>
+        <% if @purchase_a&.content_unit %>
+          <%= f.hidden_field :content_unit_name, value: @purchase_a.content_unit.name %>
+        <% end %>
         <div>
           <%= f.label :content_quantity, "内容量" ,class: "text-black" %>
           <div class="mt-1 flex items-center border border-light-gray rounded-lg bg-white focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition">
@@ -82,14 +90,21 @@
       <div class="invisible text-center h-7" data-compare-target="badgeB">
         <span class="bg-primary text-white text-xs font-bold px-3 py-1 rounded-full">おトク！</span>
       </div>
-      <h2 class="text-xl font-bold text-center mb-3">商品B</h2>
+      <h2 class="text-xl font-bold text-center mb-3">
+        <%= @purchase_a&.item&.name || "商品" %>B
+      </h2>
       <%= form_with model: @purchase_b, url: new_item_registration_path, method: :get, scope: :purchase_b, class: "space-y-4" do |f| %>
-        <div>
+        <% if @purchase_a&.item %>
+          <%= f.hidden_field :item_name, value: @purchase_a.item.name %>
+        <% end %>
+        <% if @purchase_a&.content_unit %>
+          <%= f.hidden_field :content_unit_name, value: @purchase_a.content_unit.name %>
+        <% end %>
           <%= f.label :content_quantity, "内容量" ,class: "text-black" %>
           <div class="mt-1 flex items-center border border-light-gray rounded-lg bg-white focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition">
             <%= f.number_field :content_quantity, placeholder: "例：500", inputmode: "decimal", class: "w-full p-2 bg-transparent outline-none text-black", data: {compare_target: "contentquantityB", action: "input->compare#calculate" } %>
           </div>
-        </div>
+        </>
         <div>
           <%= f.label :pack_quantity, "パック数", class: "text-black" %>
           <div class="mt-1 flex items-center border border-light-gray rounded-lg bg-white focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition">
@@ -144,6 +159,6 @@
   </div>
   <%# ─── お得表示（stimulusより計算結果出力時のみ表示） ─── %>
   <div class="mt-4">
-    <div class="bg-orange-100 text-orange-600 rounded-xl text-center py-1 rounded-xl font-semibold text-lg invisible h-10" data-compare-target="compareResultItem"></div>
+    <div class="bg-accent/20 text-accent rounded-xl text-center py-1 rounded-xl font-semibold text-3xl invisible h-12" data-compare-target="compareResultItem"></div>
   </div>
 </div>

--- a/app/views/purchases/index.html.erb
+++ b/app/views/purchases/index.html.erb
@@ -42,7 +42,7 @@
           <div class="flex flex-col items-center justify-center border-r border-light-gray px-5 py-5">
             <span class="text-sm text-dark-gray mb-1">1<%= @lowest_purchase.content_unit.name %>あたり</span>
             <p class="leading-none">
-              <span class="text-5xl font-bold text-accent"><%= @lowest_purchase.unit_price %></span>
+              <span class="text-3xl md:text-5xl font-bold text-accent"><%= @lowest_purchase.unit_price %></span>
               <span class="text-lg text-accent ml-0.5">円</span>
             </p>
           </div>


### PR DESCRIPTION
### 関連ISSUE
---
close #314 

### 変更内容
---
- 比較画面にてレスポンシブ対応を実施。
- 購入履歴から遷移時、購入履歴の商品名が表示できるよう実施しました。

### 動作確認
---

### 補足・レビュアーへのメモ
---
購入履歴→比較画面→商品登録の遷移において、パラメータが適切に反映されるようにしました。