### PR TITLE
配色デザインの調整

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -5,7 +5,6 @@
 @theme {
   /* 以下は配色を記述 */
   --color-primary: #6EA016; /* 明るい緑色 */
-  --color-secondary: #6EA016; /* 暗い緑色 */
   --color-accent: #F39800; /* オレンジ */
   --color-neutral: #FCFDF7; /* 背景色 */
   --color-error: #E65540; /* 赤 */
@@ -16,8 +15,6 @@
   --color-dark-gray: #818181; /* 濃灰 */
   --color-middle-gray: #B1B1B1; /* 中間灰 */
   --color-light-gray: #DFDFDF; /* 薄灰 */
-/* #F9D01F;黄色 */
-/*  #E65540;赤 */
 
   --color-flash-success-bg: #f7fee7;
   --color-flash-success-text: #166534;

--- a/app/javascript/controllers/restore_values_controller.js
+++ b/app/javascript/controllers/restore_values_controller.js
@@ -19,12 +19,12 @@ export default class extends Controller {
 
     let restored = false
 
-    if (data.content_quantity && !this.contentQuantityTarget.value) {
+    if (data.content_quantity) {
       this.contentQuantityTarget.value = data.content_quantity
       this.highlight(this.contentQuantityTarget)
       restored = true
     }
-    if (data.content_unit_name && !this.contentUnitTarget.value) {
+    if (data.content_unit_name) {
       this.contentUnitTarget.value = data.content_unit_name
       this.highlight(this.contentUnitTarget)
       restored = true

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -23,8 +23,8 @@
         <%# アクションボタン %>
         <div class="swipe-actions" data-swipe-target="actions" style="transform: translateX(100%);">
 
-          <%= link_to "編集", edit_category_path(category), data: { action: "touchend->swipe#stopPropagation" }, class: "flex items-center justify-center w-16 bg-blue-400 text-white text-xs font-medium self-stretch" %>
-          <%= link_to "削除", category_path(category), data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？", action: "touchend->swipe#stopPropagation" }, class: "flex items-center justify-center w-16 bg-error text-white text-xs font-medium border-none cursor-pointer h-full" %>
+          <%= link_to "編集", edit_category_path(category), data: { action: "touchend->swipe#stopPropagation" }, class: "flex items-center justify-center w-16 bg-blue-400 text-white text-sm font-medium self-stretch" %>
+          <%= link_to "削除", category_path(category), data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？", action: "touchend->swipe#stopPropagation" }, class: "flex items-center justify-center w-16 bg-error text-white text-sm font-medium border-none cursor-pointer h-full" %>
         </div>
       </div>
     <% end %>

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -8,11 +8,11 @@
 <% if @categories.any? %>
   <div class="space-y-4">
     <% @categories.each do |category| %>
-      <div class="swipe-card" data-controller="swipe" data-action="touchstart->swipe#touchstart touchend->swipe#touchend touchstart@document->swipe#outsideClick">
+      <div class="swipe-card border border-light-gray" data-controller="swipe" data-action="touchstart->swipe#touchstart touchend->swipe#touchend touchstart@document->swipe#outsideClick">
 
         <%# カテゴリー名：常に左端に固定表示 %>
         <div class="absolute top-0 left-0 bottom-0 flex items-center px-5 z-10">
-          <span class="text-sm font-bold text-dark-gray"><%= category.name %></span>
+          <span class="text-sm font-bold text-black"><%= category.name %></span>
         </div>
 
         <%# カードリンク（スライドする層）：右側に配置 %>
@@ -29,9 +29,9 @@
       </div>
     <% end %>
   </div>
-  <%# 商品登録ボタン（FAB） %>
+  <!-- カテゴリー登録遷移ボタン -->
   <div class="fixed bottom-28 left-0 right-0 mx-auto max-w-xl px-6 flex justify-end z-25">
-    <%= link_to new_category_path, class: "card bg-primary text-white px-6 py-4 rounded-full flex items-center font-bold", data: { controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" } do %>
+    <%= link_to new_category_path, class: "card bg-accent text-white px-6 py-4 rounded-full flex items-center font-bold", data: { controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" } do %>
       <span class="text-lg">カテゴリー追加</span>
       <span class="material-symbols-outlined">add</span>
     <% end %>
@@ -51,7 +51,7 @@
       よく使うカテゴリーを登録しましょう
     </p>
 
-    <!-- 商品登録遷移ボタン -->
+    <!-- カテゴリー登録遷移ボタン -->
     <div class="w-full px-6 mb-8">
       <%= link_to new_category_path, class: "card bg-primary text-white px-6 py-4 rounded-full flex items-center justify-center font-bold", data: { controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" } do %>
         <span class="text-xl tracking-widest">カテゴリーを登録する</span>

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -17,7 +17,7 @@
 
         <%# カードリンク（スライドする層）：右側に配置 %>
         <div class="swipe-inner" data-swipe-target="inner">
-          <span class="material-symbols-outlined text-gray-300 text-sm">keyboard_double_arrow_right</span>
+          <span class="material-symbols-outlined text-light-gray text-sm">keyboard_double_arrow_right</span>
         </div>
 
         <%# アクションボタン %>

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -12,7 +12,7 @@
 
         <%# カテゴリー名：常に左端に固定表示 %>
         <div class="absolute top-0 left-0 bottom-0 flex items-center px-5 z-10">
-          <span class="text-sm font-bold text-gray-800"><%= category.name %></span>
+          <span class="text-sm font-bold text-dark-gray"><%= category.name %></span>
         </div>
 
         <%# カードリンク（スライドする層）：右側に配置 %>
@@ -23,16 +23,8 @@
         <%# アクションボタン %>
         <div class="swipe-actions" data-swipe-target="actions" style="transform: translateX(100%);">
 
-          <%= link_to "編集", edit_category_path(category),
-                data: { action: "touchend->swipe#stopPropagation" },
-                class: "flex items-center justify-center w-16
-                        bg-blue-400 text-white text-xs font-medium self-stretch" %>
-
-          <%= link_to "削除", category_path(category),
-                data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？", action: "touchend->swipe#stopPropagation" },
-                class: "flex items-center justify-center w-16
-                        bg-red-400 text-white text-xs font-medium
-                        border-none cursor-pointer h-full" %>
+          <%= link_to "編集", edit_category_path(category), data: { action: "touchend->swipe#stopPropagation" }, class: "flex items-center justify-center w-16 bg-blue-400 text-white text-xs font-medium self-stretch" %>
+          <%= link_to "削除", category_path(category), data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？", action: "touchend->swipe#stopPropagation" }, class: "flex items-center justify-center w-16 bg-error text-white text-xs font-medium border-none cursor-pointer h-full" %>
         </div>
       </div>
     <% end %>

--- a/app/views/content_units/index.html.erb
+++ b/app/views/content_units/index.html.erb
@@ -24,8 +24,8 @@
         <%# アクションボタン %>
         <div class="swipe-actions" data-swipe-target="actions" style="transform: translateX(100%);">
 
-          <%= link_to "編集", edit_content_unit_path(content_unit), data: { action: "touchend->swipe#stopPropagation" }, class: "flex items-center justify-center w-16 bg-blue-400 text-white text-xs font-medium self-stretch" %>
-          <%= link_to "削除", content_unit_path(content_unit), data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？", action: "touchend->swipe#stopPropagation" }, class: "flex items-center justify-center w-16 bg-error text-white text-xs font-medium border-none cursor-pointer h-full" %>
+          <%= link_to "編集", edit_content_unit_path(content_unit), data: { action: "touchend->swipe#stopPropagation" }, class: "flex items-center justify-center w-16 bg-blue-400 text-white text-sm font-medium self-stretch" %>
+          <%= link_to "削除", content_unit_path(content_unit), data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？", action: "touchend->swipe#stopPropagation" }, class: "flex items-center justify-center w-16 bg-error text-white text-sm font-medium border-none cursor-pointer h-full" %>
         </div>
       </div>
     <% end %>

--- a/app/views/content_units/index.html.erb
+++ b/app/views/content_units/index.html.erb
@@ -18,7 +18,7 @@
 
         <%# カードリンク（スライドする層）：右側に配置 %>
         <div class="swipe-inner" data-swipe-target="inner">
-          <span class="material-symbols-outlined text-gray-300 text-sm">keyboard_double_arrow_right</span>
+          <span class="material-symbols-outlined text-light-gray text-sm">keyboard_double_arrow_right</span>
         </div>
 
         <%# アクションボタン %>

--- a/app/views/content_units/index.html.erb
+++ b/app/views/content_units/index.html.erb
@@ -13,7 +13,7 @@
 
         <%# 単位（内容量）：常に左端に固定表示 %>
         <div class="absolute top-0 left-0 bottom-0 flex items-center px-5 z-10">
-          <span class="text-sm font-bold text-gray-800"><%= content_unit.name %></span>
+          <span class="text-sm font-bold text-dark-gray"><%= content_unit.name %></span>
         </div>
 
         <%# カードリンク（スライドする層）：右側に配置 %>
@@ -24,16 +24,8 @@
         <%# アクションボタン %>
         <div class="swipe-actions" data-swipe-target="actions" style="transform: translateX(100%);">
 
-          <%= link_to "編集", edit_content_unit_path(content_unit),
-                data: { action: "touchend->swipe#stopPropagation" },
-                class: "flex items-center justify-center w-16
-                        bg-blue-400 text-white text-xs font-medium self-stretch" %>
-
-          <%= link_to "削除", content_unit_path(content_unit),
-                data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？", action: "touchend->swipe#stopPropagation" },
-                class: "flex items-center justify-center w-16
-                        bg-red-400 text-white text-xs font-medium
-                        border-none cursor-pointer h-full" %>
+          <%= link_to "編集", edit_content_unit_path(content_unit), data: { action: "touchend->swipe#stopPropagation" }, class: "flex items-center justify-center w-16 bg-blue-400 text-white text-xs font-medium self-stretch" %>
+          <%= link_to "削除", content_unit_path(content_unit), data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？", action: "touchend->swipe#stopPropagation" }, class: "flex items-center justify-center w-16 bg-error text-white text-xs font-medium border-none cursor-pointer h-full" %>
         </div>
       </div>
     <% end %>

--- a/app/views/content_units/index.html.erb
+++ b/app/views/content_units/index.html.erb
@@ -9,11 +9,11 @@
 
   <div class="space-y-4">
     <% @content_units.each do |content_unit| %>
-      <div class="swipe-card" data-controller="swipe" data-action="touchstart->swipe#touchstart touchend->swipe#touchend touchstart@document->swipe#outsideClick">
+      <div class="swipe-card border border-light-gray" data-controller="swipe" data-action="touchstart->swipe#touchstart touchend->swipe#touchend touchstart@document->swipe#outsideClick">
 
         <%# 単位（内容量）：常に左端に固定表示 %>
         <div class="absolute top-0 left-0 bottom-0 flex items-center px-5 z-10">
-          <span class="text-sm font-bold text-dark-gray"><%= content_unit.name %></span>
+          <span class="text-sm font-bold text-black"><%= content_unit.name %></span>
         </div>
 
         <%# カードリンク（スライドする層）：右側に配置 %>
@@ -30,9 +30,9 @@
       </div>
     <% end %>
   </div>
-  <%# 商品登録ボタン（FAB） %>
+  <!--単位（内容量）登録遷移ボタン -->
   <div class="fixed bottom-28 left-0 right-0 mx-auto max-w-xl px-6 flex justify-end z-25">
-    <%= link_to new_content_unit_path, class: "card bg-primary text-white px-6 py-4 rounded-full flex items-center font-bold", data: { controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" } do %>
+    <%= link_to new_content_unit_path, class: "card bg-accent text-white px-6 py-4 rounded-full flex items-center font-bold", data: { controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" } do %>
       <span class="text-lg">単位（内容量）追加</span>
       <span class="material-symbols-outlined">add</span>
     <% end %>
@@ -52,7 +52,7 @@
       よく使う単位を登録しましょう
     </p>
 
-    <!-- 商品登録遷移ボタン -->
+    <!-- 単位（内容量）登録遷移ボタン -->
     <div class="w-full px-6 mb-8">
       <%= link_to new_content_unit_path, class: "card bg-primary text-white px-6 py-4 rounded-full flex items-center justify-center font-bold", data: { controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" } do %>
         <span class="text-xl tracking-widest">単位（内容量）を登録する</span>

--- a/app/views/home/top.html.erb
+++ b/app/views/home/top.html.erb
@@ -257,13 +257,13 @@
 </section>
 
 <!-- フッター（利用規約・プライバシーポリシー・著作権マーク） -->
-<footer class="bg-white border-t border-slate-200 dark:border-slate-700 p-4">
-  <div class="max-w-screen-xl mx-auto flex flex-col items-center gap-4 text-sm text-slate-600 dark:text-slate-400">
+<footer class="bg-white border-t border-light-gray p-4">
+  <div class="max-w-screen-xl mx-auto flex flex-col items-center gap-4 text-sm">
     <div class="flex flex-wrap items-center justify-center gap-x-2 gap-y-1">
       <%= link_to "利用規約", terms_path, class: "font-bold link text-primary whitespace-nowrap" %>
       <%= link_to "プライバシーポリシー", privacy_policy_path, class: "font-bold link text-primary whitespace-nowrap" %>
       <%= link_to "お問い合わせ", "https://docs.google.com/forms/d/e/1FAIpQLSckG9kXNz8uKZLA1j2pEQ5W9_VSLcwqYyGZyWky0v_rzOvljg/viewform?usp=header", class: "font-bold link text-primary whitespace-nowrap" %>
     </div>
-    <p>© <%= Time.current.year %> SokoNote</p>
+    <p class="text-black">© <%= Time.current.year %> SokoNote</p>
   </div>
 </footer>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -135,10 +135,10 @@
         <% end %>
       <% end %>
       <!-- 商品登録遷移ボタン -->
-      <div class="fixed bottom-28 left-0 right-0 mx-auto max-w-3xl px-6 flex justify-end z-25">
+      <div class="fixed bottom-28 left-0 right-0 mx-auto max-w-xl px-6 flex justify-end z-25">
         <%= link_to new_item_registration_path, class: "card bg-accent text-white px-6 py-4 rounded-full flex items-center justify-center font-bold", data: { controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" } do %>
           <span class="text-lg">商品登録</span>
-          <span class="material-symbols-outlined">add</span>
+          <span class="material-symbols-outlined">add_2</span>
         <% end %>
       </div>
     </div>

--- a/app/views/purchases/index.html.erb
+++ b/app/views/purchases/index.html.erb
@@ -154,7 +154,7 @@
     <div class="space-y-2">
       <% @purchases.each do |purchase| %>
         <% is_lowest = purchase.id == @lowest_purchase&.id %>
-        <div class="swipe-card" data-controller="swipe" data-action="touchstart->swipe#touchstart touchend->swipe#touchend touchstart@document->swipe#outsideClick">
+        <div class="swipe-card <%= is_lowest ? 'border border-accent' : 'border border-light-gray' %>" data-controller="swipe" data-action="touchstart->swipe#touchstart touchend->swipe#touchend touchstart@document->swipe#outsideClick">
 
           <!-- 左側の緑ボーダー線の固定 -->
           <div class="absolute left-0 top-0 bottom-0 w-1.5 z-30 <%= is_lowest ? 'bg-accent' : 'bg-primary' %> rounded-l-2xl"></div>
@@ -235,7 +235,7 @@
               </div>
 
               <!-- 5段目：単価 -->
-              <div class="<%= is_lowest ? 'bg-accent/10' : 'bg-primary/10' %> -mx-3 -ml-6 -mb-3 px-8 py-2 rounded-br-2xl">
+              <div class="<%= is_lowest ? 'bg-accent/10' : 'bg-primary/10' %> -mr-15 -ml-6 -mb-3 px-8 py-2 rounded-br-2xl">
                 <span class="text-2xl font-bold <%= is_lowest ? 'text-accent' : 'text-primary' %>">
                   <%= purchase.unit_price %>
                 </span>
@@ -248,7 +248,7 @@
             </div>
           </div>
           <!-- swipe-inner：アイコンのみ・スライドする層 -->
-          <div class="swipe-inner rounded-2xl <%= is_lowest ? 'border border-accent' : 'border border-light-gray' %>" style="min-height: 11rem;" data-swipe-target="inner">
+          <div class="swipe-inner rounded-2xl" style="min-height: 11rem;" data-swipe-target="inner">
             <span class="material-symbols-outlined text-light-gray text-sm">keyboard_double_arrow_right</span>
           </div>
 

--- a/app/views/purchases/index.html.erb
+++ b/app/views/purchases/index.html.erb
@@ -261,7 +261,7 @@
             <% end %>
             <%= link_to item_purchase_path(@item, purchase),
                   data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？", action: "touchend->swipe#stopPropagation" },
-                  class: "flex items-center justify-center w-16 bg-red-400 text-white text-xs font-medium border-none cursor-pointer h-full" do %>
+                  class: "flex items-center justify-center w-16 bg-error text-white text-xs font-medium border-none cursor-pointer h-full" do %>
               <span class="material-symbols-outlined" style="font-size:18px;">delete</span>
             <% end %>
           </div>

--- a/app/views/purchases/index.html.erb
+++ b/app/views/purchases/index.html.erb
@@ -254,16 +254,8 @@
 
           <!-- スライドした時に表示される層 -->
           <div class="swipe-actions" data-swipe-target="actions" style="transform: translateX(100%);">
-            <%= link_to edit_item_purchase_path(@item, purchase),
-                  data: { action: "touchend->swipe#stopPropagation" },
-                  class: "flex items-center justify-center w-16 bg-blue-400 text-white text-xs font-medium self-stretch" do %>
-              <span class="material-symbols-outlined" style="font-size:18px;">edit</span>
-            <% end %>
-            <%= link_to item_purchase_path(@item, purchase),
-                  data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？", action: "touchend->swipe#stopPropagation" },
-                  class: "flex items-center justify-center w-16 bg-error text-white text-xs font-medium border-none cursor-pointer h-full" do %>
-              <span class="material-symbols-outlined" style="font-size:18px;">delete</span>
-            <% end %>
+            <%= link_to "編集", edit_item_purchase_path(@item, purchase), data: { action: "touchend->swipe#stopPropagation" }, class: "flex items-center justify-center w-16 bg-blue-400 text-white text-sm font-medium self-stretch" %>
+            <%= link_to "削除", item_purchase_path(@item, purchase), data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？", action: "touchend->swipe#stopPropagation" }, class: "flex items-center justify-center w-16 bg-error text-white text-sm font-medium border-none cursor-pointer h-full" %>
           </div>
         </div>
       <% end %>

--- a/app/views/stores/index.html.erb
+++ b/app/views/stores/index.html.erb
@@ -9,11 +9,11 @@
 
   <div class="space-y-4">
     <% @stores.each do |store| %>
-      <div class="swipe-card" data-controller="swipe" data-action="touchstart->swipe#touchstart touchend->swipe#touchend touchstart@document->swipe#outsideClick">
+      <div class="swipe-card border border-light-gray" data-controller="swipe" data-action="touchstart->swipe#touchstart touchend->swipe#touchend touchstart@document->swipe#outsideClick">
 
         <%# 店舗名：常に左端に固定表示 %>
         <div class="absolute top-0 left-0 bottom-0 flex items-center px-5 z-10">
-          <span class="text-sm font-bold text-dark-gray"><%= store.name %></span>
+          <span class="text-sm font-bold text-black"><%= store.name %></span>
         </div>
 
         <%# カードリンク（スライドする層）：右側に配置 %>
@@ -30,9 +30,9 @@
       </div>
     <% end %>
   </div>
-  <%# 商品登録ボタン（FAB） %>
+  <!-- 店舗登録遷移ボタン -->
   <div class="fixed bottom-28 left-0 right-0 mx-auto max-w-xl px-6 flex justify-end z-25">
-    <%= link_to new_store_path, class: "card bg-primary text-white px-6 py-4 rounded-full flex items-center font-bold", data: { controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" } do %>
+    <%= link_to new_store_path, class: "card bg-accent text-white px-6 py-4 rounded-full flex items-center font-bold", data: { controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" } do %>
       <span class="text-lg">店舗追加</span>
       <span class="material-symbols-outlined">add</span>
     <% end %>
@@ -52,7 +52,7 @@
       よく使う店舗を登録しましょう
     </p>
 
-    <!-- 商品登録遷移ボタン -->
+    <!-- 店舗登録遷移ボタン -->
     <div class="w-full px-6 mb-8">
       <%= link_to new_store_path, class: "card bg-primary text-white px-6 py-4 rounded-full flex items-center justify-center font-bold", data: { controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" } do %>
         <span class="text-xl tracking-widest">店舗を登録する</span>

--- a/app/views/stores/index.html.erb
+++ b/app/views/stores/index.html.erb
@@ -24,8 +24,8 @@
         <%# アクションボタン %>
         <div class="swipe-actions" data-swipe-target="actions" style="transform: translateX(100%);">
 
-          <%= link_to "編集", edit_store_path(store), data: { action: "touchend->swipe#stopPropagation" }, class: "flex items-center justify-center w-16 bg-blue-400 text-white text-xs font-medium self-stretch" %>
-          <%= link_to "削除", store_path(store), data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？", action: "touchend->swipe#stopPropagation" }, class: "flex items-center justify-center w-16 bg-error text-white text-xs font-medium border-none cursor-pointer h-full" %>
+          <%= link_to "編集", edit_store_path(store), data: { action: "touchend->swipe#stopPropagation" }, class: "flex items-center justify-center w-16 bg-blue-400 text-white text-sm font-medium self-stretch" %>
+          <%= link_to "削除", store_path(store), data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？", action: "touchend->swipe#stopPropagation" }, class: "flex items-center justify-center w-16 bg-error text-white text-sm font-medium border-none cursor-pointer h-full" %>
         </div>
       </div>
     <% end %>

--- a/app/views/stores/index.html.erb
+++ b/app/views/stores/index.html.erb
@@ -18,7 +18,7 @@
 
         <%# カードリンク（スライドする層）：右側に配置 %>
         <div class="swipe-inner" data-swipe-target="inner">
-          <span class="material-symbols-outlined text-gray-300 text-sm">keyboard_double_arrow_right</span>
+          <span class="material-symbols-outlined text-light-gray text-sm">keyboard_double_arrow_right</span>
         </div>
 
         <%# アクションボタン %>

--- a/app/views/stores/index.html.erb
+++ b/app/views/stores/index.html.erb
@@ -13,7 +13,7 @@
 
         <%# 店舗名：常に左端に固定表示 %>
         <div class="absolute top-0 left-0 bottom-0 flex items-center px-5 z-10">
-          <span class="text-sm font-bold text-gray-800"><%= store.name %></span>
+          <span class="text-sm font-bold text-dark-gray"><%= store.name %></span>
         </div>
 
         <%# カードリンク（スライドする層）：右側に配置 %>
@@ -25,7 +25,7 @@
         <div class="swipe-actions" data-swipe-target="actions" style="transform: translateX(100%);">
 
           <%= link_to "編集", edit_store_path(store), data: { action: "touchend->swipe#stopPropagation" }, class: "flex items-center justify-center w-16 bg-blue-400 text-white text-xs font-medium self-stretch" %>
-          <%= link_to "削除", store_path(store), data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？", action: "touchend->swipe#stopPropagation" }, class: "flex items-center justify-center w-16 bg-red-400 text-white text-xs font-medium border-none cursor-pointer h-full" %>
+          <%= link_to "削除", store_path(store), data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？", action: "touchend->swipe#stopPropagation" }, class: "flex items-center justify-center w-16 bg-error text-white text-xs font-medium border-none cursor-pointer h-full" %>
         </div>
       </div>
     <% end %>

--- a/app/views/users/passwords/edit.html.erb
+++ b/app/views/users/passwords/edit.html.erb
@@ -22,7 +22,7 @@
         </div>
         <div class="flex items-center border <%= f.object.errors[:password].any? ? "border-error border-2" : "border-light-gray" %> rounded-xl px-3 py-3 bg-white focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition">
           <span class="material-symbols-outlined text-middle-gray mr-2" style="font-size: 20px;">lock</span>
-          <%= f.password_field :password, autocomplete: "new-password", placeholder: "••••••••", class: "flex-1 outline-none text-gray-700 bg-transparent placeholder-gray-400" %>
+          <%= f.password_field :password, autocomplete: "new-password", placeholder: "••••••••", class: "flex-1 outline-none text-dark-gray bg-transparent placeholder-middle-gray" %>
         </div>
         <%= render "shared/field_error", object: f.object, field: :password %>
       </div>
@@ -31,7 +31,7 @@
         <%= f.label :password_confirmation, class: "block text-black font-semibold mb-2" %>
         <div class="flex items-center border <%= f.object.errors[:password_confirmation].any? ? "border-error border-2" : "border-light-gray" %> rounded-xl px-3 py-3 bg-white focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition">
           <span class="material-symbols-outlined text-middle-gray mr-2" style="font-size: 20px;">lock</span>
-          <%= f.password_field :password_confirmation, autocomplete: "new-password", placeholder: "••••••••", class: "flex-1 outline-none text-gray-700 bg-transparent placeholder-gray-400" %>
+          <%= f.password_field :password_confirmation, autocomplete: "new-password", placeholder: "••••••••", class: "flex-1 outline-none text-dark-gray bg-transparent placeholder-middle-gray" %>
         </div>
         <%= render "shared/field_error", object: f.object, field: :password_confirmation %>
       </div>

--- a/app/views/users/passwords/new.html.erb
+++ b/app/views/users/passwords/new.html.erb
@@ -18,7 +18,7 @@
           <span class="material-symbols-outlined text-middle-gray mr-2" style="font-size: 20px;">
             mail
           </span>
-          <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "example@email.com", required: true,  class: "flex-1 outline-none text-gray-700 bg-transparent placeholder-gray-400" %>
+          <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "example@email.com", required: true,  class: "flex-1 outline-none text-dark-gray bg-transparent placeholder-middle-gray" %>
         </div>
         <%= render "shared/field_error", object: f.object, field: :email %>
       </div>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -18,7 +18,7 @@
           <span class="material-symbols-outlined text-middle-gray mr-2" style="font-size: 20px;">
             account_circle
           </span>
-          <%= f.text_field :name, autofocus: true, placeholder: "お名前", class: "flex-1 outline-none text-black bg-transparent placeholder-gray-400"%>
+          <%= f.text_field :name, autofocus: true, placeholder: "お名前", class: "flex-1 outline-none text-black bg-transparent placeholder-middle-gray" %>
         </div>
         <%= render "shared/field_error", object: f.object, field: :name %>
       </div>
@@ -29,7 +29,7 @@
           <span class="material-symbols-outlined text-middle-gray mr-2" style="font-size: 20px;">
             mail
           </span>
-          <%= f.email_field :email, placeholder: "example@email.com", class: "flex-1 outline-none text-black bg-transparent placeholder-gray-400" %>
+          <%= f.email_field :email, placeholder: "example@email.com", class: "flex-1 outline-none text-black bg-transparent placeholder-middle-gray" %>
         </div>
         <%= render "shared/field_error", object: f.object, field: :email %>
       </div>
@@ -45,7 +45,7 @@
         </div>
         <div class="flex items-center border <%= f.object.errors[:password].any? ? "border-error border-2" : "border-light-gray" %> rounded-xl px-3 py-3 bg-white focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition">
           <span class="material-symbols-outlined text-middle-gray mr-2" style="font-size: 20px;">lock</span>
-          <%= f.password_field :password, autocomplete: "new-password", placeholder: "••••••••", class: "flex-1 outline-none text-gray-700 bg-transparent placeholder-gray-400" %>
+          <%= f.password_field :password, autocomplete: "new-password", placeholder: "••••••••", class: "flex-1 outline-none text-dark-gray bg-transparent placeholder-middle-gray" %>
         </div>
         <%= render "shared/field_error", object: f.object, field: :password %>
       </div>
@@ -54,7 +54,7 @@
         <%= f.label :password_confirmation, class: "block text-black font-semibold mb-2" %>
         <div class="flex items-center border <%= f.object.errors[:password_confirmation].any? ? "border-error border-2" : "border-light-gray" %> rounded-xl px-3 py-3 bg-white focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition">
           <span class="material-symbols-outlined text-middle-gray mr-2" style="font-size: 20px;">lock</span>
-          <%= f.password_field :password_confirmation, autocomplete: "new-password", placeholder: "••••••••", class: "flex-1 outline-none text-gray-700 bg-transparent placeholder-gray-400" %>
+          <%= f.password_field :password_confirmation, autocomplete: "new-password", placeholder: "••••••••", class: "flex-1 outline-none text-dark-gray bg-transparent placeholder-middle-gray" %>
         </div>
         <%= render "shared/field_error", object: f.object, field: :password_confirmation %>
       </div>


### PR DESCRIPTION
### 関連ISSUE
---
close #198

### 変更内容
---
- tailwindCSSの配色を定義し、各ビューへ反映させました。

### 動作確認
---
- ブラウザでの配色変更は特にありません。

### 補足・レビュアーへのメモ
---
編集・削除のボタンの統一化と、購入履歴のcard枠色と背景色の変更、各マスタのcard枠色を微修正しました。