### PR TITLE
fix: permission_policyの再設定

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,8 @@
 class ApplicationController < ActionController::Base
   # アクション実行前にログインしているか確認
   before_action :authenticate_user!
+  # セキュリティヘッダーのpermissions_policyの事前処理
+  before_action :set_permissions_policy_header
 
   def after_sign_in_path_for(resources)
     items_path
@@ -9,4 +11,10 @@ class ApplicationController < ActionController::Base
   allow_browser versions: :modern
 
   add_flash_types :success, :notice, :error
+
+  # configに設定しているpermissions_policyがfeature-policyに変換されるため
+  # controllerにて直接設定（セキュリティヘッダー）
+  def set_permissions_policy_header
+    response.headers["Permissions-Policy"] ="camera=(), gyroscope=(), microphone=(), usb=(), payment=(), geolocation=(), fullscreen=(self)"
+  end
 end


### PR DESCRIPTION
### 関連ISSUE
---
close #332

### 変更内容
---
- セキュリティヘッダーのpermissions_policyを再設定しました。

### 動作確認
---
- mainにマージ後、無料ツール「Security Headers」で確認

### 補足・レビュアーへのメモ
---