### PR TITLE
Fix/line in app browser delete confirm

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -68,4 +68,7 @@
   }
 }
 
-
+/* ダイアログの中央配置 */
+#turbo-confirm {
+  margin: auto;
+}

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,7 +1,20 @@
 // Entry point for the build script in your package.json
-import "@hotwired/turbo-rails"
+import { Turbo } from "@hotwired/turbo-rails"
 import "./controllers"
 import "./ga4"
+
+// Turboの確認処理を自前のダイアログに差し替える
+Turbo.setConfirmMethod((message) => {
+  return new Promise((resolve) => {
+    const dialog = document.getElementById("turbo-confirm")
+    dialog.querySelector("p").textContent = message
+    dialog.showModal()
+
+    dialog.addEventListener("close", () => {
+      resolve(dialog.returnValue === "confirm")
+    }, { once: true })
+  })
+})
 
 // 遷移完了時に閉じる
 document.addEventListener("turbo:load", () => {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -63,5 +63,6 @@
     <% if user_signed_in? && !content_for?(:lp_layout) %>
       <%= render 'shared/footer' %>
     <% end %>
+    <%= render "shared/turbo_confirm_dialog" %>
   </body>
 </html>

--- a/app/views/shared/_turbo_confirm_dialog.html.erb
+++ b/app/views/shared/_turbo_confirm_dialog.html.erb
@@ -1,3 +1,4 @@
+<!-- 削除ボタン実行時のダイアログ表示 -->
 <dialog id="turbo-confirm" class="m-auto rounded-2xl max-w-[90vw] w-100 p-6 backdrop:bg-black/80">
   <p class="text-black text-center font-bold leading-relaxed mb-5"></p>
   <form method="dialog" class="flex gap-2">

--- a/app/views/shared/_turbo_confirm_dialog.html.erb
+++ b/app/views/shared/_turbo_confirm_dialog.html.erb
@@ -1,0 +1,11 @@
+<dialog id="turbo-confirm" class="m-auto rounded-2xl max-w-[90vw] w-100 p-6 backdrop:bg-black/80">
+  <p class="text-black text-center font-bold leading-relaxed mb-5"></p>
+  <form method="dialog" class="flex gap-2">
+    <button value="cancel" class="flex-1 py-3 px-2 rounded-full border-2 border-gray-300 text-gray-700 font-bold text-sm">
+      キャンセル
+    </button>
+    <button value="confirm" class="flex-1 py-3 px-2 rounded-full bg-error text-white font-bold text-sm">
+      削除する
+    </button>
+  </form>
+</dialog>

--- a/app/views/users/passwords/edit.html.erb
+++ b/app/views/users/passwords/edit.html.erb
@@ -22,7 +22,7 @@
         </div>
         <div class="flex items-center border <%= f.object.errors[:password].any? ? "border-error border-2" : "border-light-gray" %> rounded-xl px-3 py-3 bg-white focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition">
           <span class="material-symbols-outlined text-middle-gray mr-2" style="font-size: 20px;">lock</span>
-          <%= f.password_field :password, autocomplete: "new-password", placeholder: "••••••••", class: "flex-1 outline-none text-dark-gray bg-transparent placeholder-middle-gray" %>
+          <%= f.password_field :password, autocomplete: "new-password", placeholder: "••••••••", class: "flex-1 outline-none text-black bg-transparent placeholder-middle-gray" %>
         </div>
         <%= render "shared/field_error", object: f.object, field: :password %>
       </div>
@@ -31,7 +31,7 @@
         <%= f.label :password_confirmation, class: "block text-black font-semibold mb-2" %>
         <div class="flex items-center border <%= f.object.errors[:password_confirmation].any? ? "border-error border-2" : "border-light-gray" %> rounded-xl px-3 py-3 bg-white focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition">
           <span class="material-symbols-outlined text-middle-gray mr-2" style="font-size: 20px;">lock</span>
-          <%= f.password_field :password_confirmation, autocomplete: "new-password", placeholder: "••••••••", class: "flex-1 outline-none text-dark-gray bg-transparent placeholder-middle-gray" %>
+          <%= f.password_field :password_confirmation, autocomplete: "new-password", placeholder: "••••••••", class: "flex-1 outline-none text-black bg-transparent placeholder-middle-gray" %>
         </div>
         <%= render "shared/field_error", object: f.object, field: :password_confirmation %>
       </div>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -45,7 +45,7 @@
         </div>
         <div class="flex items-center border <%= f.object.errors[:password].any? ? "border-error border-2" : "border-light-gray" %> rounded-xl px-3 py-3 bg-white focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition">
           <span class="material-symbols-outlined text-middle-gray mr-2" style="font-size: 20px;">lock</span>
-          <%= f.password_field :password, autocomplete: "new-password", placeholder: "••••••••", class: "flex-1 outline-none text-dark-gray bg-transparent placeholder-middle-gray" %>
+          <%= f.password_field :password, autocomplete: "new-password", placeholder: "••••••••", class: "flex-1 outline-none text-black bg-transparent placeholder-middle-gray" %>
         </div>
         <%= render "shared/field_error", object: f.object, field: :password %>
       </div>
@@ -54,7 +54,7 @@
         <%= f.label :password_confirmation, class: "block text-black font-semibold mb-2" %>
         <div class="flex items-center border <%= f.object.errors[:password_confirmation].any? ? "border-error border-2" : "border-light-gray" %> rounded-xl px-3 py-3 bg-white focus-within:border-primary focus-within:ring-1 focus-within:ring-primary transition">
           <span class="material-symbols-outlined text-middle-gray mr-2" style="font-size: 20px;">lock</span>
-          <%= f.password_field :password_confirmation, autocomplete: "new-password", placeholder: "••••••••", class: "flex-1 outline-none text-dark-gray bg-transparent placeholder-middle-gray" %>
+          <%= f.password_field :password_confirmation, autocomplete: "new-password", placeholder: "••••••••", class: "flex-1 outline-none text-black bg-transparent placeholder-middle-gray" %>
         </div>
         <%= render "shared/field_error", object: f.object, field: :password_confirmation %>
       </div>


### PR DESCRIPTION
### 関連ISSUE
---
close #343

### 変更内容
---
- 削除確認用の自作ダイアログを実装しました。

### 動作確認
---
- 削除ボタンを選択し、ダイアログが表示されるか確認
- キャンセルを選択すると画面が前画面に戻り、データは削除されない
- 削除を選択すると削除が実行され、ダイアログ画面がなくなる。
- LINEブラウザ内で実行して削除されるかどうか確認。

### 補足・レビュアーへのメモ
---
未ログイン時において、フォームのテキスト色を灰色から黒色に変更しました。