### PR TITLE
商品名変更時に購入履歴0件の商品を自動削除

### DIFF
--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -11,6 +11,8 @@ class Purchase < ApplicationRecord
   # --- バリデーション前に実行 ---
   before_validation :normalize_brand
 
+  # --- purchasesのupdateアクション後に実行 ---
+  after_update :cleanup_unused_item
 
   # --- Purchaseモデルのアソシエーション ---
   belongs_to :user
@@ -36,5 +38,13 @@ class Purchase < ApplicationRecord
   def normalize_brand
     self.brand = brand&.gsub(/\A[[:space:]]+|[[:space:]]+\z/, "")   # 全角半角空白削除
     self.brand = nil if brand.blank? # 空ならnil
+  end
+
+  # --- 商品名更新時、更新前の商品名の購入履歴が0件になった場合、削除する処理 ---
+  def cleanup_unused_item
+    return unless saved_change_to_item_id?
+    old_item_id = item_id_before_last_save
+    return if Purchase.where(item_id: old_item_id).exists?
+    Item.find_by(id: old_item_id)&.destroy
   end
 end

--- a/spec/models/purchase_spec.rb
+++ b/spec/models/purchase_spec.rb
@@ -316,4 +316,36 @@ RSpec.describe Purchase, type: :model do
       expect(purchase.brand).to be_nil
     end
   end
+
+  # ============================================================
+  # コールバック
+  # after_update :cleanup_unused_item の動作確認
+  # ============================================================
+  describe "after_update :cleanup_unused_item" do
+    context "保存した商品名（item_id）が変更された時" do
+      let(:new_item) { create(:item, user: user) }
+      context "保存前の商品名の購入履歴が0件の時" do
+        it "変更前の商品名（item）は削除される" do
+          purchase.save!
+          purchase.update!(item: new_item)
+          expect(Item.exists?(item.id)).to be false
+        end
+      end
+      context "保存前の商品名の購入履歴が1件以上がある場合" do
+        it "変更前の商品名（item）は削除されない" do
+          purchase.save!
+          create(:purchase, user: user, item: item, store: store, content_unit: content_unit, pack_unit: pack_unit)
+          purchase.update!(item: new_item)
+          expect(Item.exists?(item.id)).to be true
+        end
+      end
+    end
+    context "商品名（item_id）が変更されていない時" do
+      it "削除処理は実行されない（既存のitemは削除されない）" do
+        purchase.save!
+        purchase.update!(content_quantity: 99)
+        expect(Item.exists?(item.id)).to be true
+      end
+    end
+  end
 end


### PR DESCRIPTION
### 関連ISSUE
---
close #346 

### 変更内容
---
- purchaseモデルに購入履歴編集時に商品名を変更した際、変更前の商品に紐づく購入履歴が0件になった場合は、変更前の商品データを自動的に削除する処理を実装しました。
- 

### 動作確認
---
前提：商品名「A」の購入履歴が1件ある状態。
- 購入履歴編集時、商品名「A」から商品名「B」にして更新した場合、商品名「A」の購入履歴は0件になるので、商品名「A」自体削除される。

前提：商品名「A」の購入履歴が2件ある状態
- 購入履歴編集時、2件のうち1件のみを商品名「A」から商品名「B」にして更新しても、商品名「A」はまだ購入履歴が1件のこっているため、削除されない。
### 補足・レビュアーへのメモ
---
ユーザーからのFBのうち、名前を間違えた！でAからBに名前を変えた認識だったが、まだAが残っていることに違和感があったので実装しました。