### PR TITLE
認証まわりのSystem spec実装

### DIFF
--- a/app/controllers/line_auth_controller.rb
+++ b/app/controllers/line_auth_controller.rb
@@ -16,7 +16,7 @@ class LineAuthController < ApplicationController
     session[:line_oauth_state] = state
     session[:line_oauth_nonce] = nonce
 
-    # LINEへのリダイレクト時に付与するクエリパラメータの準備
+      # LINEへのリダイレクト時に付与するクエリパラメータの準備
     query = { response_type: "code", client_id: ENV["LINE_CHANNEL_ID"], redirect_uri: line_callback_url, state: state, scope: "profile openid", nonce: nonce }
 
     # リダイレクト時のURL

--- a/app/controllers/line_auth_controller.rb
+++ b/app/controllers/line_auth_controller.rb
@@ -16,7 +16,6 @@ class LineAuthController < ApplicationController
     session[:line_oauth_state] = state
     session[:line_oauth_nonce] = nonce
 
-      # LINEへのリダイレクト時に付与するクエリパラメータの準備
     query = { response_type: "code", client_id: ENV["LINE_CHANNEL_ID"], redirect_uri: line_callback_url, state: state, scope: "profile openid", nonce: nonce }
 
     # リダイレクト時のURL

--- a/app/views/home/top.html.erb
+++ b/app/views/home/top.html.erb
@@ -11,7 +11,7 @@
 </section>
 
 <!-- ファーストビュー -->
-<section class="relative" style="background-image: url('<%= asset_path("lp/hero.jpg") %>'); background-size: cover; background-position: center;">
+<section class="hero relative" style="background-image: url('<%= asset_path("lp/hero.jpg") %>'); background-size: cover; background-position: center;">
   <!-- 白オーバーレイ -->
   <div class="absolute inset-0 bg-white/50"></div>
 
@@ -239,7 +239,7 @@
 </section>
 
 <!-- 最終CTA（コール・トゥ・アクション） -->
-<section class="w-full bg-primary/20 mt-10 py-10">
+<section class="final-cta w-full bg-primary/20 mt-10 py-10">
   <div class="flex justify-center items-center gap-2 mx-5">
     <span class="text-3xl md:text-5xl font-bold text-black">さぁ</span>
     <%= image_tag "lp/name.png", class: "h-10 md:h-16 w-auto", alt: "SokoNote" %>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -37,7 +37,7 @@
         <% end %>
       </div>
       
-      <div class="mb-5 px-2">
+      <div class="default-login mb-5 px-2">
         <%= f.button :submit, class: "card w-full bg-primary text-white px-6 py-4 rounded-full flex items-center justify-center font-bold text-xl tracking-widest", data: { controller: "button", action: "touchstart->button#press touchend->button#release touchcancel->button#release" } do %>
           <%= t("devise.sessions.new.sign_in") %>
           <span class="material-symbols-outlined">login</span>

--- a/spec/system/home_spec.rb
+++ b/spec/system/home_spec.rb
@@ -1,31 +1,41 @@
-# require "rails_helper"
+require "rails_helper"
 
-# RSpec.describe "Home", type: :system do
-#   before do
-#     driven_by(:rack_test)
-#   end
+RSpec.describe "Home", type: :system do
+  before do
+    driven_by(:rack_test)
+  end
 
-#   describe "ホーム画面の表示" do
-#     it "ログインボタンと新規登録ボタンが表示される" do
-#       visit root_path
-#       expect(page).to have_link("ログイン")
-#       expect(page).to have_link("新規登録")
-#     end
+  describe "ホーム画面の表示" do
+    it "ログインボタンと新規登録ボタンが表示される" do
+      visit root_path
+      expect(page).to have_link("ログイン")
+      expect(page).to have_link("メールアドレスで新規登録")
+    end
+  end
 
-#   describe "ログインボタン" do
-#     it "クリックするとログイン画面に遷移する" do
-#       visit root_path
-#       click_link "ログイン"
-#       expect(current_path).to eq new_user_session_path
-#     end
-#   end
+  describe "ログインボタン" do
+    it "クリックするとログイン画面に遷移する" do
+      visit root_path
+      click_link "ログイン"
+      expect(current_path).to eq new_user_session_path
+    end
+  end
 
-#   describe "新規登録ボタン" do
-#       it "クリックすると新規登録画面に遷移する" do
-#         visit root_path
-#         click_link "新規登録"
-#         expect(current_path).to eq new_user_registration_path
-#       end
-#     end
-#   end
-# end
+  describe "新規登録ボタン" do
+    it "ファーストビューのリンクをクリックすると新規登録画面に遷移する" do
+      visit root_path
+      within(".hero") do
+        click_link "メールアドレスで新規登録"
+      end
+      expect(current_path).to eq new_user_registration_path
+    end
+
+    it "最終CTAのリンクをクリックすると新規画面登録に遷移する" do
+      visit root_path
+      within(".final-cta") do
+        click_link "メールアドレスで新規登録"
+      end
+      expect(current_path).to eq new_user_registration_path
+    end
+  end
+end

--- a/spec/system/users/passwords/edit_spec.rb
+++ b/spec/system/users/passwords/edit_spec.rb
@@ -1,0 +1,101 @@
+require 'rails_helper'
+
+RSpec.describe "パスワードリセット画面", type: :system do
+  let(:user) { create(:user) }
+  let(:token) { user.send(:set_reset_password_token) }
+
+  before do
+    driven_by(:rack_test)
+    visit edit_user_password_path(reset_password_token: token)
+  end
+
+  def fill_in_form(password:, password_confirmation: nil)
+    fill_in "user_password", with: password
+    fill_in "user_password_confirmation", with: password_confirmation || password
+  end
+
+  def submit_form
+    within "form[action='#{user_password_path}']" do
+      click_button
+    end
+  end
+
+  describe "画面表示" do
+    it "見出しが表示される" do
+      expect(page).to have_content("パスワードを変更")
+    end
+
+    it "各入力欄が表示される" do
+      expect(page).to have_field("user_password")
+      expect(page).to have_field("user_password_confirmation")
+    end
+
+    it "変更ボタンが表示される" do
+      expect(page).to have_button("パスワードを変更する")
+    end
+
+    it "ログイン画面に戻るリンクが表示される" do
+      expect(page).to have_link("ログイン画面に戻る", href: new_user_session_path)
+    end
+  end
+
+  describe "パスワード変更" do
+    context "入力値が正常な場合" do
+      it "変更に成功し新しいパスワードでログインできる" do
+        fill_in_form(password: "newpassword")
+        submit_form
+        expect(page).to have_content("パスワードが正しく変更されました。")
+        expect(user.reload.valid_password?("newpassword")).to be true
+      end
+    end
+
+    context "パスワードが未入力の場合" do
+      it "変更に失敗しエラーメッセージが表示される" do
+        fill_in_form(password: "")
+        submit_form
+        expect(page).to have_content("パスワードの変更に失敗しました")
+      end
+    end
+
+    context "パスワードが6文字未満の場合" do
+      it "変更に失敗しエラーメッセージが表示される" do
+        fill_in_form(password: "pass1")
+        submit_form
+        expect(page).to have_content("パスワードの変更に失敗しました")
+      end
+    end
+
+    context "パスワードに空白が含まれる場合" do
+      it "変更に失敗しエラーメッセージが表示される" do
+        fill_in_form(password: "pass word")
+        submit_form
+        expect(page).to have_content("は空白があると登録ができません")
+      end
+    end
+
+    context "パスワードと確認用が一致しない場合" do
+      it "変更に失敗しエラーメッセージが表示される" do
+        fill_in_form(password: "newpassword", password_confirmation: "different")
+        submit_form
+        expect(page).to have_content("パスワードの変更に失敗しました")
+      end
+    end
+
+    context "トークンが無効な場合" do
+      it "変更に失敗しエラーメッセージが表示される" do
+        visit edit_user_password_path(reset_password_token: "invalid_token")
+        fill_in_form(password: "newpassword")
+        submit_form
+        expect(page).to have_content("パスワードの変更に失敗しました")
+        expect(user.reload.valid_password?("newpassword")).to be false
+      end
+    end
+  end
+
+  describe "画面遷移" do
+    it "ログイン画面に遷移できる" do
+      click_link "ログイン画面に戻る"
+      expect(page).to have_current_path(new_user_session_path)
+    end
+  end
+end

--- a/spec/system/users/passwords/new_spec.rb
+++ b/spec/system/users/passwords/new_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+RSpec.describe "パスワードリセットメール送信画面", type: :system do
+  let(:user) { create(:user) }
+
+  before do
+    driven_by(:rack_test)
+    visit new_user_password_path
+  end
+
+  describe "画面表示" do
+    it "見出しが表示される" do
+      expect(page).to have_content("パスワードを忘れた方へ")
+    end
+
+    it "メールアドレス入力欄が表示される" do
+      expect(page).to have_field("メールアドレス")
+    end
+
+    it "送信ボタンが表示される" do
+      expect(page).to have_button("再設定メールを送信")
+    end
+
+    it "ログイン画面に戻るリンクが表示される" do
+      expect(page).to have_link("ログイン画面に戻る")
+    end
+  end
+
+  describe "フォーム送信" do
+    context "登録済みメールアドレスを入力した場合" do
+      it "完了メッセージが表示される" do
+        fill_in "メールアドレス", with: user.email
+        click_button "再設定メールを送信"
+        expect(page).to have_content("パスワード再設定メールを送信しました")
+      end
+    end
+
+    context "未登録のメールアドレスを入力した場合" do
+      it "登録済みと同じ完了メッセージが表示される（セキュリティ仕様）" do
+        fill_in "メールアドレス", with: "notfound@example.com"
+        click_button "再設定メールを送信"
+        expect(page).to have_content("パスワード再設定メールを送信しました")
+      end
+    end
+
+    context "メールアドレスを未入力で送信した場合" do
+      it "エラーメッセージが表示される" do
+        click_button "再設定メールを送信"
+        expect(page).to have_content("メールアドレスを入力してください")
+      end
+    end
+  end
+
+  describe "画面遷移" do
+    it "ログイン画面に戻るリンクをクリックするとログイン画面に遷移する" do
+      click_link "ログイン画面に戻る"
+      expect(current_path).to eq new_user_session_path
+    end
+  end
+end

--- a/spec/system/users/registrations/new_spec.rb
+++ b/spec/system/users/registrations/new_spec.rb
@@ -1,0 +1,136 @@
+require 'rails_helper'
+
+RSpec.describe "ユーザー新規登録画面", type: :system do
+  let(:user) { build(:user) }
+
+  before do
+    driven_by(:rack_test)
+    visit new_user_registration_path
+  end
+
+  def fill_in_form(name: user.name, email: user.email, password: "password", password_confirmation: nil)
+    fill_in "user_name", with: name
+    fill_in "user_email", with: email
+    fill_in "user_password", with: password
+    fill_in "user_password_confirmation", with: password_confirmation || password
+  end
+
+  describe "画面表示" do
+    it "見出しが表示される" do
+      expect(page).to have_content("新規アカウント登録")
+    end
+
+    it "各入力欄が表示される" do
+      expect(page).to have_field("user_name")
+      expect(page).to have_field("user_email")
+      expect(page).to have_field("user_password")
+      expect(page).to have_field("user_password_confirmation")
+    end
+
+    it "利用規約・プライバシーポリシーのリンクが表示される" do
+      expect(page).to have_link("利用規約", href: terms_path)
+      expect(page).to have_link("プライバシーポリシー", href: privacy_policy_path)
+    end
+
+    it "アカウント登録ボタンが表示される" do
+      expect(page).to have_button("新規アカウント登録")
+    end
+
+    it "LINEで新規登録ボタンが表示される" do
+      expect(page).to have_button("LINEで新規登録")
+    end
+
+    it "ログイン画面に遷移するリンクが表示される" do
+      expect(page).to have_link("アカウントをお持ちの方はこちら")
+    end
+  end
+
+  describe "アカウント登録" do
+    context "入力値が正常な場合" do
+      it "登録に成功し完了メッセージが表示される" do
+        fill_in_form
+        check "agreement"
+        expect {
+          click_button "新規アカウント登録"
+          expect(page).to have_content("アカウント登録が完了しました。")
+        }.to change(User, :count).by(1)
+      end
+    end
+
+    context "ニックネームが未入力の場合" do
+      it "登録に失敗しエラーメッセージが表示される" do
+        fill_in_form(name: "")
+        check "agreement"
+        expect {
+          click_button "新規アカウント登録"
+        }.not_to change(User, :count)
+        expect(page).to have_content("アカウントの登録に失敗しました")
+      end
+    end
+
+    context "メールアドレスが未入力の場合" do
+      it "登録に失敗しエラーメッセージが表示される" do
+        fill_in_form(email: "")
+        check "agreement"
+        expect {
+          click_button "新規アカウント登録"
+        }.not_to change(User, :count)
+        expect(page).to have_content("アカウントの登録に失敗しました")
+      end
+    end
+
+    context "メールアドレスが登録済みの場合" do
+      let!(:existing_user) { create(:user) }
+
+      it "登録に失敗しエラーメッセージが表示される" do
+        fill_in_form(email: existing_user.email)
+        check "agreement"
+        expect {
+          click_button "新規アカウント登録"
+        }.not_to change(User, :count)
+        expect(page).to have_content("アカウントの登録に失敗しました")
+        expect(page).to have_content("は現在使用できません")
+      end
+    end
+
+    context "パスワードが6文字未満の場合" do
+      it "登録に失敗しエラーメッセージが表示される" do
+        fill_in_form(password: "pass1")
+        check "agreement"
+        expect {
+          click_button "新規アカウント登録"
+        }.not_to change(User, :count)
+        expect(page).to have_content("アカウントの登録に失敗しました")
+      end
+    end
+
+    context "パスワードに空白が含まれる場合" do
+      it "登録に失敗しエラーメッセージが表示される" do
+        fill_in_form(password: "pass word")
+        check "agreement"
+        expect {
+          click_button "新規アカウント登録"
+        }.not_to change(User, :count)
+        expect(page).to have_content("は空白があると登録ができません")
+      end
+    end
+
+    context "パスワードと確認用が一致しない場合" do
+      it "登録に失敗しエラーメッセージが表示される" do
+        fill_in_form(password: "password", password_confirmation: "different")
+        check "agreement"
+        expect {
+          click_button "新規アカウント登録"
+        }.not_to change(User, :count)
+        expect(page).to have_content("アカウントの登録に失敗しました")
+      end
+    end
+  end
+
+  describe "画面遷移" do
+    it "ログイン画面に遷移できる" do
+      click_link "アカウントをお持ちの方はこちら"
+      expect(page).to have_current_path(new_user_session_path)
+    end
+  end
+end

--- a/spec/system/users/sessions/new_spec.rb
+++ b/spec/system/users/sessions/new_spec.rb
@@ -1,0 +1,103 @@
+require 'rails_helper'
+
+RSpec.describe "ログイン画面", type: :system do
+  let(:user) { create(:user) }
+
+  before do
+    driven_by(:rack_test)
+    visit new_user_session_path
+  end
+
+  # パスワード欄はビューで id: "password-field" が指定されているためid指定で入力
+  def fill_in_form(email:, password:)
+    fill_in "user_email", with: email
+    fill_in "password-field", with: password
+  end
+
+  describe "画面表示" do
+    it "見出しが表示される" do
+      expect(page).to have_content("ログイン")
+    end
+
+    it "各入力欄が表示される" do
+      expect(page).to have_field("user_email")
+      expect(page).to have_field("password-field")
+    end
+
+    it "次回自動ログインのチェックボックスが表示される" do
+      expect(page).to have_field("user_remember_me")
+    end
+
+    it "ログインボタンが表示される" do
+      expect(page).to have_button("ログイン")
+    end
+
+    it "LINEでログインボタンが表示される" do
+      expect(page).to have_button("LINEでログイン")
+    end
+
+    it "新規登録画面に遷移するリンクが表示される" do
+      expect(page).to have_link("アカウントをお持ちでない方はこちら")
+    end
+
+    it "パスワードリセット画面に遷移するリンクが表示される" do
+      expect(page).to have_link("パスワードを忘れましたか？")
+    end
+  end
+
+  describe "ログイン" do
+    context "入力値が正常な場合" do
+      it "ログインに成功する" do
+        fill_in_form(email: user.email, password: "password")
+        within(".default-login") do
+          click_button "ログイン"
+        end
+        expect(page).to have_content("ログインしました。")
+      end
+    end
+
+    context "メールアドレスが誤っている場合" do
+      it "ログインに失敗しエラーメッセージが表示される" do
+        fill_in_form(email: "wrong@example.com", password: "password")
+        within(".default-login") do
+          click_button "ログイン"
+        end
+        expect(page).to have_content("メールアドレスまたはパスワードが違います。")
+        expect(page).to have_current_path(new_user_session_path)
+      end
+    end
+
+    context "パスワードが誤っている場合" do
+      it "ログインに失敗しエラーメッセージが表示される" do
+        fill_in_form(email: user.email, password: "wrongpass")
+        within(".default-login") do
+          click_button "ログイン"
+        end
+        expect(page).to have_content("メールアドレスまたはパスワードが違います。")
+        expect(page).to have_current_path(new_user_session_path)
+      end
+    end
+
+    context "未入力の場合" do
+      it "ログインに失敗しエラーメッセージが表示される" do
+        fill_in_form(email: "", password: "")
+        within(".default-login") do
+          click_button "ログイン"
+        end
+        expect(page).to have_content("メールアドレスまたはパスワードが違います。")
+      end
+    end
+  end
+
+  describe "画面遷移" do
+    it "新規登録画面に遷移できる" do
+      click_link "アカウントをお持ちでない方はこちら"
+      expect(page).to have_current_path(new_user_registration_path)
+    end
+
+    it "パスワードリセット画面に遷移できる" do
+      click_link "パスワードを忘れましたか？"
+      expect(page).to have_current_path(new_user_password_path)
+    end
+  end
+end


### PR DESCRIPTION
### 関連ISSUE
---
close #352 

### 変更内容
---
- トップ画面およびログイン前の認証関係のsystemspecを実装しました

Rails7のサポート終了により急遽中断し、バージョンアップの対応を実施するため、breakmanは失敗します。